### PR TITLE
fix: ws security advisory from ethers v5 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,18 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-kms": "^3.391.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
         "@types/node": "^18.14.6",
         "asn1.js": "^5.4.1",
         "aws-sdk": "^2.1438.0",
         "bn.js": "^5.2.1",
-        "debug": "^4.3.4",
-        "ethers": "^5.4.7"
+        "debug": "^4.3.4"
       },
       "devDependencies": {
         "@babel/cli": "^7.21.0",
@@ -3493,32 +3499,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@ethersproject/abi": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
-      "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/hash": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
-    },
     "node_modules/@ethersproject/abstract-provider": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
@@ -3605,25 +3585,6 @@
         "@ethersproject/bytes": "^5.7.0"
       }
     },
-    "node_modules/@ethersproject/basex": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
-      "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0"
-      }
-    },
     "node_modules/@ethersproject/bignumber": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
@@ -3680,33 +3641,6 @@
         "@ethersproject/bignumber": "^5.7.0"
       }
     },
-    "node_modules/@ethersproject/contracts": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
-      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abi": "^5.7.0",
-        "@ethersproject/abstract-provider": "^5.7.0",
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0"
-      }
-    },
     "node_modules/@ethersproject/hash": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
@@ -3731,65 +3665,6 @@
         "@ethersproject/logger": "^5.7.0",
         "@ethersproject/properties": "^5.7.0",
         "@ethersproject/strings": "^5.7.0"
-      }
-    },
-    "node_modules/@ethersproject/hdnode": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
-      "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/basex": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/pbkdf2": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0",
-        "@ethersproject/signing-key": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "@ethersproject/wordlists": "^5.7.0"
-      }
-    },
-    "node_modules/@ethersproject/json-wallets": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
-      "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/hdnode": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/pbkdf2": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/random": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "aes-js": "3.0.0",
-        "scrypt-js": "3.0.1"
       }
     },
     "node_modules/@ethersproject/keccak256": {
@@ -3844,25 +3719,6 @@
         "@ethersproject/logger": "^5.7.0"
       }
     },
-    "node_modules/@ethersproject/pbkdf2": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
-      "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0"
-      }
-    },
     "node_modules/@ethersproject/properties": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
@@ -3878,62 +3734,6 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/logger": "^5.7.0"
-      }
-    },
-    "node_modules/@ethersproject/providers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
-      "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-provider": "^5.7.0",
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/base64": "^5.7.0",
-        "@ethersproject/basex": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/hash": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/networks": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/random": "^5.7.0",
-        "@ethersproject/rlp": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "@ethersproject/web": "^5.7.0",
-        "bech32": "1.1.4",
-        "ws": "7.4.6"
-      }
-    },
-    "node_modules/@ethersproject/random": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
-      "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0"
       }
     },
@@ -3954,26 +3754,6 @@
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0"
-      }
-    },
-    "node_modules/@ethersproject/sha2": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
-      "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "hash.js": "1.1.7"
       }
     },
     "node_modules/@ethersproject/signing-key": {
@@ -3997,29 +3777,6 @@
         "bn.js": "^5.2.1",
         "elliptic": "6.5.4",
         "hash.js": "1.1.7"
-      }
-    },
-    "node_modules/@ethersproject/solidity": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
-      "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/strings": {
@@ -4068,58 +3825,6 @@
         "@ethersproject/signing-key": "^5.7.0"
       }
     },
-    "node_modules/@ethersproject/units": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
-      "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0"
-      }
-    },
-    "node_modules/@ethersproject/wallet": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
-      "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-provider": "^5.7.0",
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/hash": "^5.7.0",
-        "@ethersproject/hdnode": "^5.7.0",
-        "@ethersproject/json-wallets": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/random": "^5.7.0",
-        "@ethersproject/signing-key": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "@ethersproject/wordlists": "^5.7.0"
-      }
-    },
     "node_modules/@ethersproject/web": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
@@ -4137,28 +3842,6 @@
       "dependencies": {
         "@ethersproject/base64": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
-    },
-    "node_modules/@ethersproject/wordlists": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
-      "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/hash": "^5.7.0",
         "@ethersproject/logger": "^5.7.0",
         "@ethersproject/properties": "^5.7.0",
         "@ethersproject/strings": "^5.7.0"
@@ -5377,134 +5060,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@octokit/auth-token": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.3.tgz",
-      "integrity": "sha512-/aFM2M4HVDBT/jjDBa84sJniv1t9Gm/rLkalaz9htOm+L+8JMj1k9w0CkUdcxNyNxZPlTxKPVko+m1VlM58ZVA==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^9.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@octokit/core": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.0.tgz",
-      "integrity": "sha512-AgvDRUg3COpR82P7PBdGZF/NNqGmtMq2NiPqeSsDIeCfYFOZ9gddqWNQHnFdEUf+YwOj4aZYmJnlPp7OXmDIDg==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/auth-token": "^3.0.0",
-        "@octokit/graphql": "^5.0.0",
-        "@octokit/request": "^6.0.0",
-        "@octokit/request-error": "^3.0.0",
-        "@octokit/types": "^9.0.0",
-        "before-after-hook": "^2.2.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@octokit/core/node_modules/before-after-hook": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
-      "dev": true
-    },
-    "node_modules/@octokit/core/node_modules/universal-user-agent": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
-      "dev": true
-    },
-    "node_modules/@octokit/endpoint": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.5.tgz",
-      "integrity": "sha512-LG4o4HMY1Xoaec87IqQ41TQ+glvIeTKqfjkCEmt5AIwDZJwQeVZFIEYXrYY6yLwK+pAScb9Gj4q+Nz2qSw1roA==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^9.0.0",
-        "is-plain-object": "^5.0.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@octokit/endpoint/node_modules/universal-user-agent": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
-      "dev": true
-    },
-    "node_modules/@octokit/graphql": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.5.tgz",
-      "integrity": "sha512-Qwfvh3xdqKtIznjX9lz2D458r7dJPP8l6r4GQkIdWQouZwHQK0mVT88uwiU2bdTU2OtT1uOlKpRciUWldpG0yQ==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/request": "^6.0.0",
-        "@octokit/types": "^9.0.0",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@octokit/graphql/node_modules/universal-user-agent": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
-      "dev": true
-    },
-    "node_modules/@octokit/openapi-types": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
-      "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA==",
-      "dev": true
-    },
-    "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.0.0.tgz",
-      "integrity": "sha512-Sq5VU1PfT6/JyuXPyt04KZNVsFOSBaYOAq2QRZUwzVlI10KFvcbUo8lR258AAQL1Et60b0WuVik+zOWKLuDZxw==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^9.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=4"
-      }
-    },
-    "node_modules/@octokit/plugin-request-log": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true,
-      "peerDependencies": {
-        "@octokit/core": ">=3"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.0.1.tgz",
-      "integrity": "sha512-pnCaLwZBudK5xCdrR823xHGNgqOzRnJ/mpC/76YPpNP7DybdsJtP7mdOwh+wYZxK5jqeQuhu59ogMI4NRlBUvA==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^9.0.0",
-        "deprecation": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=3"
-      }
-    },
     "node_modules/@octokit/plugin-retry": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.0.1.tgz",
@@ -5582,43 +5137,6 @@
         "@octokit/openapi-types": "^19.0.2"
       }
     },
-    "node_modules/@octokit/request": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.3.tgz",
-      "integrity": "sha512-TNAodj5yNzrrZ/VxP+H5HiYaZep0H3GU0O7PaF+fhDrt8FPrnkei9Aal/txsN/1P7V3CPiThG0tIvpPDYUsyAA==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/endpoint": "^7.0.0",
-        "@octokit/request-error": "^3.0.0",
-        "@octokit/types": "^9.0.0",
-        "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.7",
-        "universal-user-agent": "^6.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@octokit/request-error": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
-      "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^9.0.0",
-        "deprecation": "^2.0.0",
-        "once": "^1.4.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@octokit/request/node_modules/universal-user-agent": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
-      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
-      "dev": true
-    },
     "node_modules/@octokit/rest": {
       "version": "15.18.3",
       "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.18.3.tgz",
@@ -5646,15 +5164,6 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
-      }
-    },
-    "node_modules/@octokit/types": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
-      "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/openapi-types": "^16.0.0"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -5690,320 +5199,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@semantic-release/changelog": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.2.tgz",
-      "integrity": "sha512-jHqfTkoPbDEOAgAP18mGP53IxeMwxTISN+GwTRy9uLu58UjARoZU8ScCgWGeO2WPkEsm57H8AkyY02W2ntIlIw==",
-      "dev": true,
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "fs-extra": "^11.0.0",
-        "lodash": "^4.17.4"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0"
-      }
-    },
-    "node_modules/@semantic-release/commit-analyzer": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
-      "integrity": "sha512-E+dr6L+xIHZkX4zNMe6Rnwg4YQrWNXK+rNsvwOPpdFppvZO1olE2fIgWhv89TkQErygevbjsZFSIxp+u6w2e5g==",
-      "dev": true,
-      "dependencies": {
-        "conventional-changelog-angular": "^5.0.0",
-        "conventional-commits-filter": "^2.0.0",
-        "conventional-commits-parser": "^3.2.3",
-        "debug": "^4.0.0",
-        "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
-        "micromatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0-beta.1"
-      }
-    },
-    "node_modules/@semantic-release/error": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
-      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/@semantic-release/git": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-10.0.1.tgz",
-      "integrity": "sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==",
-      "dev": true,
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "debug": "^4.0.0",
-        "dir-glob": "^3.0.0",
-        "execa": "^5.0.0",
-        "lodash": "^4.17.4",
-        "micromatch": "^4.0.0",
-        "p-reduce": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/p-reduce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
-      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@semantic-release/git/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@semantic-release/github": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.7.tgz",
-      "integrity": "sha512-VtgicRIKGvmTHwm//iqTh/5NGQwsncOMR5vQK9pMT92Aem7dv37JFKKRuulUsAnUOIlO4G8wH3gPiBAA0iW0ww==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/rest": "^19.0.0",
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "bottleneck": "^2.18.1",
-        "debug": "^4.0.0",
-        "dir-glob": "^3.0.0",
-        "fs-extra": "^11.0.0",
-        "globby": "^11.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
-        "mime": "^3.0.0",
-        "p-filter": "^2.0.0",
-        "p-retry": "^4.0.0",
-        "url-join": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0-beta.1"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/@octokit/rest": {
-      "version": "19.0.7",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.7.tgz",
-      "integrity": "sha512-HRtSfjrWmWVNp2uAkEpQnuGMJsu/+dBr47dRc5QVgsCbnIc1+GFEaoKBWkYG+zjrsHpSqcAElMio+n10c0b5JA==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/core": "^4.1.0",
-        "@octokit/plugin-paginate-rest": "^6.0.0",
-        "@octokit/plugin-request-log": "^1.0.4",
-        "@octokit/plugin-rest-endpoint-methods": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "dev": true,
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@semantic-release/npm": {
@@ -6399,121 +5594,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@semantic-release/release-notes-generator": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-10.0.3.tgz",
-      "integrity": "sha512-k4x4VhIKneOWoBGHkx0qZogNjCldLPRiAjnIpMnlUh6PtaWXp/T+C9U7/TaNDDtgDa5HMbHl4WlREdxHio6/3w==",
-      "dev": true,
-      "dependencies": {
-        "conventional-changelog-angular": "^5.0.0",
-        "conventional-changelog-writer": "^5.0.0",
-        "conventional-commits-filter": "^2.0.0",
-        "conventional-commits-parser": "^3.2.3",
-        "debug": "^4.0.0",
-        "get-stream": "^6.0.0",
-        "import-from": "^4.0.0",
-        "into-stream": "^6.0.0",
-        "lodash": "^4.17.4",
-        "read-pkg-up": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0-beta.1"
-      }
-    },
-    "node_modules/@semantic-release/release-notes-generator/node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@sentry/core": {
-      "version": "7.41.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.41.0.tgz",
-      "integrity": "sha512-yT3wl3wMfPymstIZRWNjuov4xhieIEPD0z9MIW9VmoemqkD5BEZsgPuvGaVIyQVMyx61GsN4H4xd0JCyNqNvLg==",
-      "dev": true,
-      "dependencies": {
-        "@sentry/types": "7.41.0",
-        "@sentry/utils": "7.41.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/node": {
-      "version": "7.41.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.41.0.tgz",
-      "integrity": "sha512-JAz0TAVvq4z7dNrDBECLB5Fd4bGDGXSOR1f63iV/8fUNsZPqqdh8LXnctPXTpcTjsdlfmjUL1CC2RQ6yKYMtTQ==",
-      "dev": true,
-      "dependencies": {
-        "@sentry/core": "7.41.0",
-        "@sentry/types": "7.41.0",
-        "@sentry/utils": "7.41.0",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@sentry/types": {
-      "version": "7.41.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.41.0.tgz",
-      "integrity": "sha512-4z9VdObynwd64i0VHCqkeIAHmsFzapL21qN41Brzb7jY/eGxjn/0rxInDGH+vkoE9qacGqiYfWj4vRNPLsC/bw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/utils": {
-      "version": "7.41.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.41.0.tgz",
-      "integrity": "sha512-SL+MGitvkakbkrOTb48rDuJp9GYx/veB6EOzYygh49+zwz4DGM7dD4/rvf/mVlgmXUzPgdGDgkVmxgX3nT7I7g==",
-      "dev": true,
-      "dependencies": {
-        "@sentry/types": "7.41.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -7403,22 +6483,10 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
     },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-      "dev": true
-    },
     "node_modules/@types/prettier": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.2.3.tgz",
       "integrity": "sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==",
-      "dev": true
-    },
-    "node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -7726,11 +6794,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/aes-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
     },
     "node_modules/agent-base": {
       "version": "4.3.0",
@@ -8288,11 +7351,6 @@
         }
       ]
     },
-    "node_modules/bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
-    },
     "node_modules/before-after-hook": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
@@ -8353,12 +7411,6 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
     },
-    "node_modules/boolean": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-      "dev": true
-    },
     "node_modules/bottleneck": {
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
@@ -8381,12 +7433,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -9188,56 +8240,11 @@
         "node": ">=10"
       }
     },
-    "node_modules/conventional-changelog-writer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
-      "integrity": "sha512-5WsuKUfxW7suLblAbFnxAcrvf6r+0b7GvNaWUwUIk0bXMnENP/PEieGKVUQrjPqwPT4o3EPAASBXiY6iHooLOQ==",
-      "dev": true,
-      "dependencies": {
-        "conventional-commits-filter": "^2.0.7",
-        "dateformat": "^3.0.0",
-        "handlebars": "^4.7.7",
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
-        "meow": "^8.0.0",
-        "semver": "^6.0.0",
-        "split": "^1.0.0",
-        "through2": "^4.0.0"
-      },
-      "bin": {
-        "conventional-changelog-writer": "cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-writer/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/conventional-commit-types": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-3.0.0.tgz",
       "integrity": "sha512-SmmCYnOniSsAa9GqWOeLqc179lfr5TRu5b4QFDkbsrJ5TZjPJx85wtOr3zn+1dbeNiXDKGPbZ72IKbPhLXh/Lg==",
       "dev": true
-    },
-    "node_modules/conventional-commits-filter": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
-      "integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
-      "dev": true,
-      "dependencies": {
-        "lodash.ismatch": "^4.4.0",
-        "modify-values": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/conventional-commits-parser": {
       "version": "3.2.4",
@@ -9266,15 +8273,6 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/core-js-compat": {
@@ -9464,15 +8462,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/dateformat": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -9596,52 +8585,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/del": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
-      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
-      "dev": true,
-      "dependencies": {
-        "globby": "^11.0.1",
-        "graceful-fs": "^4.2.4",
-        "is-glob": "^4.0.1",
-        "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.2",
-        "p-map": "^4.0.0",
-        "rimraf": "^3.0.2",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/del/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/del/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -9683,12 +8626,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -10142,12 +9079,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es6-error": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true
     },
     "node_modules/es6-promise": {
       "version": "4.2.8",
@@ -10870,53 +9801,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ethers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abi": "5.7.0",
-        "@ethersproject/abstract-provider": "5.7.0",
-        "@ethersproject/abstract-signer": "5.7.0",
-        "@ethersproject/address": "5.7.0",
-        "@ethersproject/base64": "5.7.0",
-        "@ethersproject/basex": "5.7.0",
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/constants": "5.7.0",
-        "@ethersproject/contracts": "5.7.0",
-        "@ethersproject/hash": "5.7.0",
-        "@ethersproject/hdnode": "5.7.0",
-        "@ethersproject/json-wallets": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
-        "@ethersproject/logger": "5.7.0",
-        "@ethersproject/networks": "5.7.1",
-        "@ethersproject/pbkdf2": "5.7.0",
-        "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.2",
-        "@ethersproject/random": "5.7.0",
-        "@ethersproject/rlp": "5.7.0",
-        "@ethersproject/sha2": "5.7.0",
-        "@ethersproject/signing-key": "5.7.0",
-        "@ethersproject/solidity": "5.7.0",
-        "@ethersproject/strings": "5.7.0",
-        "@ethersproject/transactions": "5.7.0",
-        "@ethersproject/units": "5.7.0",
-        "@ethersproject/wallet": "5.7.0",
-        "@ethersproject/web": "5.7.1",
-        "@ethersproject/wordlists": "5.7.0"
-      }
-    },
     "node_modules/events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -11241,9 +10125,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -11388,26 +10272,6 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       }
-    },
-    "node_modules/fromentries": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/fs-extra": {
       "version": "11.1.0",
@@ -11659,38 +10523,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/global-agent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
-      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-      "dev": true,
-      "dependencies": {
-        "boolean": "^3.0.1",
-        "es6-error": "^4.1.1",
-        "matcher": "^3.0.0",
-        "roarr": "^2.15.3",
-        "semver": "^7.3.2",
-        "serialize-error": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=10.0"
-      }
-    },
-    "node_modules/global-agent/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/global-dirs": {
@@ -12117,18 +10949,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/import-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
-      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/import-from-esm": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.3.3.tgz",
@@ -12331,22 +11151,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/into-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
-      "integrity": "sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==",
-      "dev": true,
-      "dependencies": {
-        "from2": "^2.3.0",
-        "p-is-promise": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-arguments": {
@@ -12584,37 +11388,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-path-cwd": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -16444,12 +15221,6 @@
       "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
       "dev": true
     },
-    "node_modules/lodash.ismatch": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
-      "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
-      "dev": true
-    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -16775,12 +15546,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/lru_map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==",
-      "dev": true
-    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -16840,101 +15605,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/marked": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
-      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
-      "dev": true,
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/marked-terminal": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-5.1.1.tgz",
-      "integrity": "sha512-+cKTOx9P4l7HwINYhzbrBSyzgxO2HaHKGZGuB1orZsMIgXYaJyfidT81VXRdpelW/PcHEWxywscePVgI/oUF6g==",
-      "dev": true,
-      "dependencies": {
-        "ansi-escapes": "^5.0.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^5.0.0",
-        "cli-table3": "^0.6.1",
-        "node-emoji": "^1.11.0",
-        "supports-hyperlinks": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=14.13.1 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "marked": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
-      }
-    },
-    "node_modules/marked-terminal/node_modules/ansi-escapes": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
-      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/marked-terminal/node_modules/chalk": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/marked-terminal/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/matcher": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
-      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/matcher/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -17104,15 +15774,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/modify-values": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
-      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -17153,15 +15814,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node_modules/node-emoji": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
-      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.21"
-      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.9",
@@ -17265,22 +15917,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/normalize-url": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/npm": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-10.2.4.tgz",
-      "integrity": "sha512-umEuYneVEYO9KoEEI8n2sSGmNQeqco/3BSeacRlqIkCzw4E7XGtYSWMeJobxzr6hZ2n9cM+u5TsMTcC5bAgoWA==",
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-10.8.2.tgz",
+      "integrity": "sha512-x/AIjFIKRllrhcb48dqUNAAZl0ig9+qMuN91RpZo3Cb2+zuibfh+KISl6+kVVyktDz230JKc208UkQwwMqyB+w==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -17289,6 +15929,7 @@
         "@npmcli/map-workspaces",
         "@npmcli/package-json",
         "@npmcli/promise-spawn",
+        "@npmcli/redact",
         "@npmcli/run-script",
         "@sigstore/tuf",
         "abbrev",
@@ -17297,8 +15938,6 @@
         "chalk",
         "ci-info",
         "cli-columns",
-        "cli-table3",
-        "columnify",
         "fastest-levenshtein",
         "fs-minipass",
         "glob",
@@ -17334,7 +15973,6 @@
         "npm-profile",
         "npm-registry-fetch",
         "npm-user-validate",
-        "npmlog",
         "p-map",
         "pacote",
         "parse-conflict-json",
@@ -17344,7 +15982,6 @@
         "semver",
         "spdx-expression-parse",
         "ssri",
-        "strip-ansi",
         "supports-color",
         "tar",
         "text-table",
@@ -17357,74 +15994,71 @@
       "dev": true,
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^7.2.1",
-        "@npmcli/config": "^8.0.2",
-        "@npmcli/fs": "^3.1.0",
-        "@npmcli/map-workspaces": "^3.0.4",
-        "@npmcli/package-json": "^5.0.0",
-        "@npmcli/promise-spawn": "^7.0.0",
-        "@npmcli/run-script": "^7.0.2",
-        "@sigstore/tuf": "^2.2.0",
+        "@npmcli/arborist": "^7.5.4",
+        "@npmcli/config": "^8.3.4",
+        "@npmcli/fs": "^3.1.1",
+        "@npmcli/map-workspaces": "^3.0.6",
+        "@npmcli/package-json": "^5.2.0",
+        "@npmcli/promise-spawn": "^7.0.2",
+        "@npmcli/redact": "^2.0.1",
+        "@npmcli/run-script": "^8.1.0",
+        "@sigstore/tuf": "^2.3.4",
         "abbrev": "^2.0.0",
         "archy": "~1.0.0",
-        "cacache": "^18.0.0",
+        "cacache": "^18.0.3",
         "chalk": "^5.3.0",
         "ci-info": "^4.0.0",
         "cli-columns": "^4.0.0",
-        "cli-table3": "^0.6.3",
-        "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
-        "glob": "^10.3.10",
+        "glob": "^10.4.2",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^7.0.1",
-        "ini": "^4.1.1",
-        "init-package-json": "^6.0.0",
-        "is-cidr": "^5.0.3",
-        "json-parse-even-better-errors": "^3.0.0",
-        "libnpmaccess": "^8.0.1",
-        "libnpmdiff": "^6.0.3",
-        "libnpmexec": "^7.0.4",
-        "libnpmfund": "^5.0.1",
-        "libnpmhook": "^10.0.0",
-        "libnpmorg": "^6.0.1",
-        "libnpmpack": "^6.0.3",
-        "libnpmpublish": "^9.0.2",
-        "libnpmsearch": "^7.0.0",
-        "libnpmteam": "^6.0.0",
-        "libnpmversion": "^5.0.1",
-        "make-fetch-happen": "^13.0.0",
-        "minimatch": "^9.0.3",
-        "minipass": "^7.0.4",
+        "hosted-git-info": "^7.0.2",
+        "ini": "^4.1.3",
+        "init-package-json": "^6.0.3",
+        "is-cidr": "^5.1.0",
+        "json-parse-even-better-errors": "^3.0.2",
+        "libnpmaccess": "^8.0.6",
+        "libnpmdiff": "^6.1.4",
+        "libnpmexec": "^8.1.3",
+        "libnpmfund": "^5.0.12",
+        "libnpmhook": "^10.0.5",
+        "libnpmorg": "^6.0.6",
+        "libnpmpack": "^7.0.4",
+        "libnpmpublish": "^9.0.9",
+        "libnpmsearch": "^7.0.6",
+        "libnpmteam": "^6.0.5",
+        "libnpmversion": "^6.0.3",
+        "make-fetch-happen": "^13.0.1",
+        "minimatch": "^9.0.5",
+        "minipass": "^7.1.1",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^10.0.1",
-        "nopt": "^7.2.0",
-        "normalize-package-data": "^6.0.0",
+        "node-gyp": "^10.1.0",
+        "nopt": "^7.2.1",
+        "normalize-package-data": "^6.0.2",
         "npm-audit-report": "^5.0.0",
         "npm-install-checks": "^6.3.0",
-        "npm-package-arg": "^11.0.1",
-        "npm-pick-manifest": "^9.0.0",
-        "npm-profile": "^9.0.0",
-        "npm-registry-fetch": "^16.1.0",
-        "npm-user-validate": "^2.0.0",
-        "npmlog": "^7.0.1",
+        "npm-package-arg": "^11.0.2",
+        "npm-pick-manifest": "^9.1.0",
+        "npm-profile": "^10.0.0",
+        "npm-registry-fetch": "^17.1.0",
+        "npm-user-validate": "^2.0.1",
         "p-map": "^4.0.0",
-        "pacote": "^17.0.4",
+        "pacote": "^18.0.6",
         "parse-conflict-json": "^3.0.1",
-        "proc-log": "^3.0.0",
+        "proc-log": "^4.2.0",
         "qrcode-terminal": "^0.12.0",
-        "read": "^2.1.0",
-        "semver": "^7.5.4",
-        "spdx-expression-parse": "^3.0.1",
-        "ssri": "^10.0.5",
-        "strip-ansi": "^7.1.0",
+        "read": "^3.0.1",
+        "semver": "^7.6.2",
+        "spdx-expression-parse": "^4.0.0",
+        "ssri": "^10.0.6",
         "supports-color": "^9.4.0",
-        "tar": "^6.2.0",
+        "tar": "^6.2.1",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^5.0.0",
+        "validate-npm-package-name": "^5.0.1",
         "which": "^4.0.0",
         "write-file-atomic": "^5.0.1"
       },
@@ -17448,16 +16082,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/npm/node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/npm/node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "dev": true,
@@ -17473,6 +16097,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
@@ -17498,6 +16134,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
       "dev": true,
@@ -17505,7 +16156,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
-      "version": "2.2.0",
+      "version": "2.2.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -17514,49 +16165,51 @@
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.1",
         "lru-cache": "^10.0.1",
-        "socks-proxy-agent": "^8.0.1"
+        "socks-proxy-agent": "^8.0.3"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "7.2.1",
+      "version": "7.5.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/fs": "^3.1.0",
-        "@npmcli/installed-package-contents": "^2.0.2",
+        "@npmcli/fs": "^3.1.1",
+        "@npmcli/installed-package-contents": "^2.1.0",
         "@npmcli/map-workspaces": "^3.0.2",
-        "@npmcli/metavuln-calculator": "^7.0.0",
+        "@npmcli/metavuln-calculator": "^7.1.1",
         "@npmcli/name-from-folder": "^2.0.0",
         "@npmcli/node-gyp": "^3.0.0",
-        "@npmcli/package-json": "^5.0.0",
-        "@npmcli/query": "^3.0.1",
-        "@npmcli/run-script": "^7.0.2",
-        "bin-links": "^4.0.1",
-        "cacache": "^18.0.0",
+        "@npmcli/package-json": "^5.1.0",
+        "@npmcli/query": "^3.1.0",
+        "@npmcli/redact": "^2.0.0",
+        "@npmcli/run-script": "^8.1.0",
+        "bin-links": "^4.0.4",
+        "cacache": "^18.0.3",
         "common-ancestor-path": "^1.0.1",
-        "hosted-git-info": "^7.0.1",
-        "json-parse-even-better-errors": "^3.0.0",
+        "hosted-git-info": "^7.0.2",
+        "json-parse-even-better-errors": "^3.0.2",
         "json-stringify-nice": "^1.1.4",
-        "minimatch": "^9.0.0",
-        "nopt": "^7.0.0",
+        "lru-cache": "^10.2.2",
+        "minimatch": "^9.0.4",
+        "nopt": "^7.2.1",
         "npm-install-checks": "^6.2.0",
-        "npm-package-arg": "^11.0.1",
-        "npm-pick-manifest": "^9.0.0",
-        "npm-registry-fetch": "^16.0.0",
-        "npmlog": "^7.0.1",
-        "pacote": "^17.0.4",
+        "npm-package-arg": "^11.0.2",
+        "npm-pick-manifest": "^9.0.1",
+        "npm-registry-fetch": "^17.0.1",
+        "pacote": "^18.0.6",
         "parse-conflict-json": "^3.0.0",
-        "proc-log": "^3.0.0",
+        "proc-log": "^4.2.0",
+        "proggy": "^2.0.0",
         "promise-all-reject-late": "^1.0.0",
-        "promise-call-limit": "^1.0.2",
+        "promise-call-limit": "^3.0.1",
         "read-package-json-fast": "^3.0.2",
         "semver": "^7.3.7",
-        "ssri": "^10.0.5",
+        "ssri": "^10.0.6",
         "treeverse": "^3.0.0",
         "walk-up-path": "^3.0.1"
       },
@@ -17568,17 +16221,17 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "8.0.2",
+      "version": "8.3.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/map-workspaces": "^3.0.2",
+        "@npmcli/package-json": "^5.1.1",
         "ci-info": "^4.0.0",
-        "ini": "^4.1.0",
-        "nopt": "^7.0.0",
-        "proc-log": "^3.0.0",
-        "read-package-json-fast": "^3.0.2",
+        "ini": "^4.1.2",
+        "nopt": "^7.2.1",
+        "proc-log": "^4.2.0",
         "semver": "^7.3.5",
         "walk-up-path": "^3.0.1"
       },
@@ -17586,35 +16239,8 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/@npmcli/disparity-colors": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "ansi-styles": "^4.3.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/disparity-colors/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/npm/node_modules/@npmcli/fs": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -17626,15 +16252,16 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "5.0.3",
+      "version": "5.0.8",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/promise-spawn": "^7.0.0",
+        "ini": "^4.1.3",
         "lru-cache": "^10.0.1",
         "npm-pick-manifest": "^9.0.0",
-        "proc-log": "^3.0.0",
+        "proc-log": "^4.0.0",
         "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
@@ -17645,7 +16272,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-      "version": "2.0.2",
+      "version": "2.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -17654,14 +16281,14 @@
         "npm-normalize-package-bin": "^3.0.0"
       },
       "bin": {
-        "installed-package-contents": "lib/index.js"
+        "installed-package-contents": "bin/index.js"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "3.0.4",
+      "version": "3.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -17676,14 +16303,15 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "7.0.0",
+      "version": "7.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "cacache": "^18.0.0",
         "json-parse-even-better-errors": "^3.0.0",
-        "pacote": "^17.0.0",
+        "pacote": "^18.0.0",
+        "proc-log": "^4.1.0",
         "semver": "^7.3.5"
       },
       "engines": {
@@ -17709,7 +16337,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "5.0.0",
+      "version": "5.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -17719,7 +16347,7 @@
         "hosted-git-info": "^7.0.0",
         "json-parse-even-better-errors": "^3.0.0",
         "normalize-package-data": "^6.0.0",
-        "proc-log": "^3.0.0",
+        "proc-log": "^4.0.0",
         "semver": "^7.5.3"
       },
       "engines": {
@@ -17727,7 +16355,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
-      "version": "7.0.0",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -17739,7 +16367,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/query": {
-      "version": "3.0.1",
+      "version": "3.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -17750,16 +16378,26 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/npm/node_modules/@npmcli/redact": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "7.0.2",
+      "version": "8.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/node-gyp": "^3.0.0",
+        "@npmcli/package-json": "^5.0.0",
         "@npmcli/promise-spawn": "^7.0.0",
         "node-gyp": "^10.0.0",
-        "read-package-json-fast": "^3.0.0",
+        "proc-log": "^4.0.0",
         "which": "^4.0.0"
       },
       "engines": {
@@ -17777,48 +16415,74 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/bundle": {
-      "version": "2.1.0",
+      "version": "2.3.2",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.2.1"
+        "@sigstore/protobuf-specs": "^0.3.2"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.2.1",
+    "node_modules/npm/node_modules/@sigstore/core": {
+      "version": "1.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
+      "version": "0.3.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "2.2.0",
+      "version": "2.3.2",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^2.1.0",
-        "@sigstore/protobuf-specs": "^0.2.1",
-        "make-fetch-happen": "^13.0.0"
+        "@sigstore/bundle": "^2.3.2",
+        "@sigstore/core": "^1.0.0",
+        "@sigstore/protobuf-specs": "^0.3.2",
+        "make-fetch-happen": "^13.0.1",
+        "proc-log": "^4.2.0",
+        "promise-retry": "^2.0.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "2.2.0",
+      "version": "2.3.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.2.1",
-        "tuf-js": "^2.1.0"
+        "@sigstore/protobuf-specs": "^0.3.2",
+        "tuf-js": "^2.2.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/verify": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^2.3.2",
+        "@sigstore/core": "^1.1.0",
+        "@sigstore/protobuf-specs": "^0.3.2"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -17834,13 +16498,13 @@
       }
     },
     "node_modules/npm/node_modules/@tufjs/models": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@tufjs/canonical-json": "2.0.0",
-        "minimatch": "^9.0.3"
+        "minimatch": "^9.0.4"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -17855,20 +16519,8 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/abort-controller": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/npm/node_modules/agent-base": {
-      "version": "7.1.0",
+      "version": "7.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -17893,15 +16545,12 @@
       }
     },
     "node_modules/npm/node_modules/ansi-regex": {
-      "version": "6.0.1",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/ansi-styles": {
@@ -17928,47 +16577,14 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/are-we-there-yet": {
-      "version": "4.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^4.1.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/base64-js": {
-      "version": "1.5.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -17983,12 +16599,15 @@
       }
     },
     "node_modules/npm/node_modules/binary-extensions": {
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
@@ -18000,41 +16619,8 @@
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/npm/node_modules/buffer": {
-      "version": "6.0.3",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/npm/node_modules/builtins": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.0.0"
-      }
-    },
     "node_modules/npm/node_modules/cacache": {
-      "version": "18.0.0",
+      "version": "18.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18044,7 +16630,7 @@
         "glob": "^10.2.2",
         "lru-cache": "^10.0.1",
         "minipass": "^7.0.3",
-        "minipass-collect": "^1.0.2",
+        "minipass-collect": "^2.0.1",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^4.0.0",
@@ -18093,7 +16679,7 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "4.0.3",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -18126,53 +16712,8 @@
         "node": ">= 10"
       }
     },
-    "node_modules/npm/node_modules/cli-columns/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/cli-columns/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/cli-table3": {
-      "version": "0.6.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      },
-      "optionalDependencies": {
-        "@colors/colors": "1.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/clone": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/npm/node_modules/cmd-shim": {
-      "version": "6.0.2",
+      "version": "6.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18198,57 +16739,8 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/color-support": {
-      "version": "1.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
-    "node_modules/npm/node_modules/columnify": {
-      "version": "1.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "strip-ansi": "^6.0.1",
-        "wcwidth": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/columnify/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/columnify/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/console-control-strings": {
-      "version": "1.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -18295,7 +16787,7 @@
       }
     },
     "node_modules/npm/node_modules/debug": {
-      "version": "4.3.4",
+      "version": "4.3.5",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -18317,26 +16809,8 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/defaults": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/delegates": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/diff": {
-      "version": "5.1.0",
+      "version": "5.2.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -18381,24 +16855,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/npm/node_modules/events": {
-      "version": "3.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.1",
       "dev": true,
@@ -18415,7 +16871,7 @@
       }
     },
     "node_modules/npm/node_modules/foreground-child": {
-      "version": "3.1.1",
+      "version": "3.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18442,72 +16898,24 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/function-bind": {
-      "version": "1.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/npm/node_modules/gauge": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^4.0.1",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/gauge/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/gauge/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/glob": {
-      "version": "10.3.10",
+      "version": "10.4.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -18519,26 +16927,8 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/has-unicode": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/hasown": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "7.0.1",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18556,7 +16946,7 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
-      "version": "7.0.0",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -18569,7 +16959,7 @@
       }
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
-      "version": "7.0.2",
+      "version": "7.0.5",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -18594,28 +16984,8 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/npm/node_modules/ieee754": {
-      "version": "1.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/npm/node_modules/ignore-walk": {
-      "version": "6.0.3",
+      "version": "6.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18645,7 +17015,7 @@
       }
     },
     "node_modules/npm/node_modules/ini": {
-      "version": "4.1.1",
+      "version": "4.1.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18654,15 +17024,15 @@
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
-      "version": "6.0.0",
+      "version": "6.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@npmcli/package-json": "^5.0.0",
         "npm-package-arg": "^11.0.0",
         "promzard": "^1.0.0",
-        "read": "^2.0.0",
-        "read-package-json": "^7.0.0",
+        "read": "^3.0.1",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "^5.0.0"
@@ -18671,11 +17041,18 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/ip": {
-      "version": "2.0.0",
+    "node_modules/npm/node_modules/ip-address": {
+      "version": "9.0.5",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "5.0.0",
@@ -18690,27 +17067,15 @@
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "5.0.3",
+      "version": "5.1.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "4.0.3"
+        "cidr-regex": "^4.1.1"
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.13.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
@@ -18735,7 +17100,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/jackspeak": {
-      "version": "2.3.6",
+      "version": "3.4.0",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -18752,8 +17117,14 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/npm/node_modules/jsbn": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
-      "version": "3.0.0",
+      "version": "3.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -18792,52 +17163,50 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "8.0.1",
+      "version": "8.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-package-arg": "^11.0.1",
-        "npm-registry-fetch": "^16.0.0"
+        "npm-package-arg": "^11.0.2",
+        "npm-registry-fetch": "^17.0.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "6.0.3",
+      "version": "6.1.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^7.2.1",
-        "@npmcli/disparity-colors": "^3.0.0",
-        "@npmcli/installed-package-contents": "^2.0.2",
-        "binary-extensions": "^2.2.0",
+        "@npmcli/arborist": "^7.5.4",
+        "@npmcli/installed-package-contents": "^2.1.0",
+        "binary-extensions": "^2.3.0",
         "diff": "^5.1.0",
-        "minimatch": "^9.0.0",
-        "npm-package-arg": "^11.0.1",
-        "pacote": "^17.0.4",
-        "tar": "^6.2.0"
+        "minimatch": "^9.0.4",
+        "npm-package-arg": "^11.0.2",
+        "pacote": "^18.0.6",
+        "tar": "^6.2.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "7.0.4",
+      "version": "8.1.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^7.2.1",
-        "@npmcli/run-script": "^7.0.2",
+        "@npmcli/arborist": "^7.5.4",
+        "@npmcli/run-script": "^8.1.0",
         "ci-info": "^4.0.0",
-        "npm-package-arg": "^11.0.1",
-        "npmlog": "^7.0.1",
-        "pacote": "^17.0.4",
-        "proc-log": "^3.0.0",
-        "read": "^2.0.0",
+        "npm-package-arg": "^11.0.2",
+        "pacote": "^18.0.6",
+        "proc-log": "^4.2.0",
+        "read": "^3.0.1",
         "read-package-json-fast": "^3.0.2",
         "semver": "^7.3.7",
         "walk-up-path": "^3.0.1"
@@ -18847,112 +17216,112 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "5.0.1",
+      "version": "5.0.12",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^7.2.1"
+        "@npmcli/arborist": "^7.5.4"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmhook": {
-      "version": "10.0.0",
+      "version": "10.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^16.0.0"
+        "npm-registry-fetch": "^17.0.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmorg": {
-      "version": "6.0.1",
+      "version": "6.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^16.0.0"
+        "npm-registry-fetch": "^17.0.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "6.0.3",
+      "version": "7.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^7.2.1",
-        "@npmcli/run-script": "^7.0.2",
-        "npm-package-arg": "^11.0.1",
-        "pacote": "^17.0.4"
+        "@npmcli/arborist": "^7.5.4",
+        "@npmcli/run-script": "^8.1.0",
+        "npm-package-arg": "^11.0.2",
+        "pacote": "^18.0.6"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "9.0.2",
+      "version": "9.0.9",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "ci-info": "^4.0.0",
-        "normalize-package-data": "^6.0.0",
-        "npm-package-arg": "^11.0.1",
-        "npm-registry-fetch": "^16.0.0",
-        "proc-log": "^3.0.0",
+        "normalize-package-data": "^6.0.1",
+        "npm-package-arg": "^11.0.2",
+        "npm-registry-fetch": "^17.0.1",
+        "proc-log": "^4.2.0",
         "semver": "^7.3.7",
-        "sigstore": "^2.1.0",
-        "ssri": "^10.0.5"
+        "sigstore": "^2.2.0",
+        "ssri": "^10.0.6"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "7.0.0",
+      "version": "7.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-registry-fetch": "^16.0.0"
+        "npm-registry-fetch": "^17.0.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmteam": {
-      "version": "6.0.0",
+      "version": "6.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^16.0.0"
+        "npm-registry-fetch": "^17.0.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "5.0.1",
+      "version": "6.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^5.0.3",
-        "@npmcli/run-script": "^7.0.2",
-        "json-parse-even-better-errors": "^3.0.0",
-        "proc-log": "^3.0.0",
+        "@npmcli/git": "^5.0.7",
+        "@npmcli/run-script": "^8.1.0",
+        "json-parse-even-better-errors": "^3.0.2",
+        "proc-log": "^4.2.0",
         "semver": "^7.3.7"
       },
       "engines": {
@@ -18960,19 +17329,16 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "10.0.2",
+      "version": "10.2.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
       "engines": {
         "node": "14 || >=16.14"
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "13.0.0",
+      "version": "13.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18986,6 +17352,7 @@
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^0.6.3",
+        "proc-log": "^4.2.0",
         "promise-retry": "^2.0.1",
         "ssri": "^10.0.0"
       },
@@ -18994,7 +17361,7 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "9.0.3",
+      "version": "9.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19009,7 +17376,7 @@
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "7.0.4",
+      "version": "7.1.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19018,31 +17385,19 @@
       }
     },
     "node_modules/npm/node_modules/minipass-collect": {
-      "version": "1.0.2",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.0.3"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-collect/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "3.0.4",
+      "version": "3.0.5",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19071,28 +17426,6 @@
       }
     },
     "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-json-stream": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsonparse": "^1.3.1",
-        "minipass": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-json-stream/node_modules/minipass": {
       "version": "3.3.6",
       "dev": true,
       "inBundle": true,
@@ -19214,7 +17547,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "10.0.1",
+      "version": "10.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19237,8 +17570,17 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/npm/node_modules/node-gyp/node_modules/proc-log": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/npm/node_modules/nopt": {
-      "version": "7.2.0",
+      "version": "7.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19253,13 +17595,12 @@
       }
     },
     "node_modules/npm/node_modules/normalize-package-data": {
-      "version": "6.0.0",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^7.0.0",
-        "is-core-module": "^2.8.1",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4"
       },
@@ -19277,7 +17618,7 @@
       }
     },
     "node_modules/npm/node_modules/npm-bundled": {
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19310,13 +17651,13 @@
       }
     },
     "node_modules/npm/node_modules/npm-package-arg": {
-      "version": "11.0.1",
+      "version": "11.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "hosted-git-info": "^7.0.0",
-        "proc-log": "^3.0.0",
+        "proc-log": "^4.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-name": "^5.0.0"
       },
@@ -19325,19 +17666,19 @@
       }
     },
     "node_modules/npm/node_modules/npm-packlist": {
-      "version": "8.0.0",
+      "version": "8.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "ignore-walk": "^6.0.0"
+        "ignore-walk": "^6.0.4"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
-      "version": "9.0.0",
+      "version": "9.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19352,56 +17693,42 @@
       }
     },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "9.0.0",
+      "version": "10.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-registry-fetch": "^16.0.0",
-        "proc-log": "^3.0.0"
+        "npm-registry-fetch": "^17.0.1",
+        "proc-log": "^4.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "16.1.0",
+      "version": "17.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@npmcli/redact": "^2.0.0",
+        "jsonparse": "^1.3.1",
         "make-fetch-happen": "^13.0.0",
         "minipass": "^7.0.2",
         "minipass-fetch": "^3.0.0",
-        "minipass-json-stream": "^1.0.1",
         "minizlib": "^2.1.2",
         "npm-package-arg": "^11.0.0",
-        "proc-log": "^3.0.0"
+        "proc-log": "^4.0.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/npm-user-validate": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npmlog": {
-      "version": "7.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "^4.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^5.0.0",
-        "set-blocking": "^2.0.0"
-      },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -19421,33 +17748,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npm/node_modules/package-json-from-dist": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/npm/node_modules/pacote": {
-      "version": "17.0.4",
+      "version": "18.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/git": "^5.0.0",
         "@npmcli/installed-package-contents": "^2.0.1",
+        "@npmcli/package-json": "^5.1.0",
         "@npmcli/promise-spawn": "^7.0.0",
-        "@npmcli/run-script": "^7.0.0",
+        "@npmcli/run-script": "^8.0.0",
         "cacache": "^18.0.0",
         "fs-minipass": "^3.0.0",
         "minipass": "^7.0.2",
         "npm-package-arg": "^11.0.0",
         "npm-packlist": "^8.0.0",
         "npm-pick-manifest": "^9.0.0",
-        "npm-registry-fetch": "^16.0.0",
-        "proc-log": "^3.0.0",
+        "npm-registry-fetch": "^17.0.0",
+        "proc-log": "^4.0.0",
         "promise-retry": "^2.0.1",
-        "read-package-json": "^7.0.0",
-        "read-package-json-fast": "^3.0.0",
-        "sigstore": "^2.0.0",
+        "sigstore": "^2.2.0",
         "ssri": "^10.0.0",
         "tar": "^6.1.11"
       },
       "bin": {
-        "pacote": "lib/bin.js"
+        "pacote": "bin/index.js"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -19477,23 +17809,23 @@
       }
     },
     "node_modules/npm/node_modules/path-scurry": {
-      "version": "1.10.1",
+      "version": "1.11.1",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^9.1.1 || ^10.0.0",
+        "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "6.0.13",
+      "version": "6.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19506,7 +17838,7 @@
       }
     },
     "node_modules/npm/node_modules/proc-log": {
-      "version": "3.0.0",
+      "version": "4.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19514,13 +17846,13 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/process": {
-      "version": "0.11.10",
+    "node_modules/npm/node_modules/proggy": {
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
+      "license": "ISC",
       "engines": {
-        "node": ">= 0.6.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
@@ -19533,7 +17865,7 @@
       }
     },
     "node_modules/npm/node_modules/promise-call-limit": {
-      "version": "1.0.2",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19561,12 +17893,12 @@
       }
     },
     "node_modules/npm/node_modules/promzard": {
-      "version": "1.0.0",
+      "version": "1.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "read": "^2.0.0"
+        "read": "^3.0.1"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -19581,12 +17913,12 @@
       }
     },
     "node_modules/npm/node_modules/read": {
-      "version": "2.1.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "mute-stream": "~1.0.0"
+        "mute-stream": "^1.0.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -19599,21 +17931,6 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/read-package-json": {
-      "version": "7.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^10.2.2",
-        "json-parse-even-better-errors": "^3.0.0",
-        "normalize-package-data": "^6.0.0",
-        "npm-normalize-package-bin": "^3.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
@@ -19629,22 +17946,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/readable-stream": {
-      "version": "4.4.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
       "dev": true,
@@ -19654,26 +17955,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/npm/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
       "dev": true,
@@ -19682,37 +17963,16 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.5.4",
+      "version": "7.6.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/npm/node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/set-blocking": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/shebang-command": {
       "version": "2.0.0",
@@ -19748,15 +18008,17 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "2.1.0",
+      "version": "2.3.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^2.1.0",
-        "@sigstore/protobuf-specs": "^0.2.1",
-        "@sigstore/sign": "^2.1.0",
-        "@sigstore/tuf": "^2.1.0"
+        "@sigstore/bundle": "^2.3.2",
+        "@sigstore/core": "^1.0.0",
+        "@sigstore/protobuf-specs": "^0.3.2",
+        "@sigstore/sign": "^2.3.2",
+        "@sigstore/tuf": "^2.3.4",
+        "@sigstore/verify": "^1.2.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -19773,28 +18035,28 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.7.1",
+      "version": "2.8.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
-      "version": "8.0.2",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.1",
         "debug": "^4.3.4",
-        "socks": "^2.7.1"
+        "socks": "^2.8.3"
       },
       "engines": {
         "node": ">= 14"
@@ -19810,13 +18072,7 @@
         "spdx-license-ids": "^3.0.0"
       }
     },
-    "node_modules/npm/node_modules/spdx-exceptions": {
-      "version": "2.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "CC-BY-3.0"
-    },
-    "node_modules/npm/node_modules/spdx-expression-parse": {
+    "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "dev": true,
       "inBundle": true,
@@ -19826,14 +18082,36 @@
         "spdx-license-ids": "^3.0.0"
       }
     },
+    "node_modules/npm/node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/npm/node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.16",
+      "version": "3.0.18",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
+    "node_modules/npm/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/npm/node_modules/ssri": {
-      "version": "10.0.5",
+      "version": "10.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19842,15 +18120,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/npm/node_modules/string-width": {
@@ -19882,61 +18151,16 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/string-width/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/string-width/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/strip-ansi": {
-      "version": "7.1.0",
+      "version": "6.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/strip-ansi-cjs": {
@@ -19948,15 +18172,6 @@
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -19974,7 +18189,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20045,14 +18260,14 @@
       }
     },
     "node_modules/npm/node_modules/tuf-js": {
-      "version": "2.1.0",
+      "version": "2.2.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@tufjs/models": "2.0.0",
+        "@tufjs/models": "2.0.1",
         "debug": "^4.3.4",
-        "make-fetch-happen": "^13.0.0"
+        "make-fetch-happen": "^13.0.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -20098,14 +18313,21 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
     "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "builtins": "^5.0.0"
-      },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -20115,15 +18337,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC"
-    },
-    "node_modules/npm/node_modules/wcwidth": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
-      }
     },
     "node_modules/npm/node_modules/which": {
       "version": "4.0.0",
@@ -20147,15 +18360,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/npm/node_modules/wide-align": {
-      "version": "1.1.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "node_modules/npm/node_modules/wrap-ansi": {
@@ -20193,15 +18397,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
       "dev": true,
@@ -20217,16 +18412,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
@@ -20250,6 +18445,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/npm/node_modules/write-file-atomic": {
@@ -20849,27 +19059,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-filter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
-      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
-      "dev": true,
-      "dependencies": {
-        "p-map": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/p-filter/node_modules/p-map": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -20940,19 +19129,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -21768,15 +19944,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -21852,29 +20019,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/roarr": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
-      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-      "dev": true,
-      "dependencies": {
-        "boolean": "^3.0.1",
-        "detect-node": "^2.0.4",
-        "globalthis": "^1.0.1",
-        "json-stringify-safe": "^5.0.1",
-        "semver-compare": "^1.0.0",
-        "sprintf-js": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/roarr/node_modules/sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-      "dev": true
     },
     "node_modules/run-async": {
       "version": "2.4.1",
@@ -21962,11 +20106,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/scrypt-js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
-    },
     "node_modules/semantic-release": {
       "version": "22.0.8",
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-22.0.8.tgz",
@@ -22011,5973 +20150,18 @@
       }
     },
     "node_modules/semantic-release-npm-github-publish": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/semantic-release-npm-github-publish/-/semantic-release-npm-github-publish-1.5.4.tgz",
-      "integrity": "sha512-0VYd5AWnpmZh3b1lSAALGWrOxpk3J+5vJVe3yhe0CagSx6GYMy8kvQ/vDhF1ZILPvr2Th489ByCIfEz7jbxcYA==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/semantic-release-npm-github-publish/-/semantic-release-npm-github-publish-1.5.5.tgz",
+      "integrity": "sha512-VDXPQGFL9kJ26m4usq4N4+n4xe6bJ1MaQkwCNlVnz9LCJch33bFCCLLP7tNZk73T8E7GUjkq+Z24wnA5clO7wA==",
       "dev": true,
-      "dependencies": {
-        "@semantic-release/changelog": "^6.0.0",
-        "@semantic-release/commit-analyzer": "^9.0.1",
-        "@semantic-release/git": "^10.0.0",
-        "@semantic-release/github": "^8.0.1",
-        "@semantic-release/npm": "^8.0.0",
-        "@semantic-release/release-notes-generator": "^10.0.2",
-        "semantic-release": "^19.0.0",
-        "snyk": "^1.720.0"
-      },
       "peerDependencies": {
-        "semantic-release": ">=18.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/@semantic-release/npm": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-8.0.3.tgz",
-      "integrity": "sha512-Qbg7x/O1t3sJqsv2+U0AL4Utgi/ymlCiUdt67Ftz9HL9N8aDML4t2tE0T9MBaYdqwD976hz57DqHHXKVppUBoA==",
-      "dev": true,
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "execa": "^5.0.0",
-        "fs-extra": "^10.0.0",
-        "lodash": "^4.17.15",
-        "nerf-dart": "^1.0.0",
-        "normalize-url": "^6.0.0",
-        "npm": "^7.0.0",
-        "rc": "^1.2.8",
-        "read-pkg": "^5.0.0",
-        "registry-auth-token": "^4.0.0",
-        "semver": "^7.1.2",
-        "tempy": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "dev": true,
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/env-ci": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
-      "integrity": "sha512-o0JdWIbOLP+WJKIUt36hz1ImQQFuN92nhsfTkHHap+J8CiI8WgGpH/a9jEGHh4/TU5BUUGjlnKXNoDb57+ne+A==",
-      "dev": true,
-      "dependencies": {
-        "execa": "^5.0.0",
-        "fromentries": "^1.3.2",
-        "java-properties": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.17"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/find-versions": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
-      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
-      "dev": true,
-      "dependencies": {
-        "semver-regex": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/hook-std": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
-      "integrity": "sha512-zZ6T5WcuBMIUVh49iPQS9t977t7C0l7OtHrpeMb5uk48JdflRX0NSFvCekfYNmGQETnLq9W/isMyHl69kxGi8g==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-7.24.2.tgz",
-      "integrity": "sha512-120p116CE8VMMZ+hk8IAb1inCPk4Dj3VZw29/n2g6UI77urJKVYb7FZUDW8hY+EBnfsjI/2yrobBgFyzo7YpVQ==",
-      "bundleDependencies": [
-        "@isaacs/string-locale-compare",
-        "@npmcli/arborist",
-        "@npmcli/ci-detect",
-        "@npmcli/config",
-        "@npmcli/map-workspaces",
-        "@npmcli/package-json",
-        "@npmcli/run-script",
-        "abbrev",
-        "ansicolors",
-        "ansistyles",
-        "archy",
-        "cacache",
-        "chalk",
-        "chownr",
-        "cli-columns",
-        "cli-table3",
-        "columnify",
-        "fastest-levenshtein",
-        "glob",
-        "graceful-fs",
-        "hosted-git-info",
-        "ini",
-        "init-package-json",
-        "is-cidr",
-        "json-parse-even-better-errors",
-        "libnpmaccess",
-        "libnpmdiff",
-        "libnpmexec",
-        "libnpmfund",
-        "libnpmhook",
-        "libnpmorg",
-        "libnpmpack",
-        "libnpmpublish",
-        "libnpmsearch",
-        "libnpmteam",
-        "libnpmversion",
-        "make-fetch-happen",
-        "minipass",
-        "minipass-pipeline",
-        "mkdirp",
-        "mkdirp-infer-owner",
-        "ms",
-        "node-gyp",
-        "nopt",
-        "npm-audit-report",
-        "npm-install-checks",
-        "npm-package-arg",
-        "npm-pick-manifest",
-        "npm-profile",
-        "npm-registry-fetch",
-        "npm-user-validate",
-        "npmlog",
-        "opener",
-        "pacote",
-        "parse-conflict-json",
-        "qrcode-terminal",
-        "read",
-        "read-package-json",
-        "read-package-json-fast",
-        "readdir-scoped-modules",
-        "rimraf",
-        "semver",
-        "ssri",
-        "tar",
-        "text-table",
-        "tiny-relative-date",
-        "treeverse",
-        "validate-npm-package-name",
-        "which",
-        "write-file-atomic"
-      ],
-      "dev": true,
-      "dependencies": {
-        "@isaacs/string-locale-compare": "*",
-        "@npmcli/arborist": "*",
-        "@npmcli/ci-detect": "*",
-        "@npmcli/config": "*",
-        "@npmcli/map-workspaces": "*",
-        "@npmcli/package-json": "*",
-        "@npmcli/run-script": "*",
-        "abbrev": "*",
-        "ansicolors": "*",
-        "ansistyles": "*",
-        "archy": "*",
-        "cacache": "*",
-        "chalk": "*",
-        "chownr": "*",
-        "cli-columns": "*",
-        "cli-table3": "*",
-        "columnify": "*",
-        "fastest-levenshtein": "*",
-        "glob": "*",
-        "graceful-fs": "*",
-        "hosted-git-info": "*",
-        "ini": "*",
-        "init-package-json": "*",
-        "is-cidr": "*",
-        "json-parse-even-better-errors": "*",
-        "libnpmaccess": "*",
-        "libnpmdiff": "*",
-        "libnpmexec": "*",
-        "libnpmfund": "*",
-        "libnpmhook": "*",
-        "libnpmorg": "*",
-        "libnpmpack": "*",
-        "libnpmpublish": "*",
-        "libnpmsearch": "*",
-        "libnpmteam": "*",
-        "libnpmversion": "*",
-        "make-fetch-happen": "*",
-        "minipass": "*",
-        "minipass-pipeline": "*",
-        "mkdirp": "*",
-        "mkdirp-infer-owner": "*",
-        "ms": "*",
-        "node-gyp": "*",
-        "nopt": "*",
-        "npm-audit-report": "*",
-        "npm-install-checks": "*",
-        "npm-package-arg": "*",
-        "npm-pick-manifest": "*",
-        "npm-profile": "*",
-        "npm-registry-fetch": "*",
-        "npm-user-validate": "*",
-        "npmlog": "*",
-        "opener": "*",
-        "pacote": "*",
-        "parse-conflict-json": "*",
-        "qrcode-terminal": "*",
-        "read": "*",
-        "read-package-json": "*",
-        "read-package-json-fast": "*",
-        "readdir-scoped-modules": "*",
-        "rimraf": "*",
-        "semver": "*",
-        "ssri": "*",
-        "tar": "*",
-        "text-table": "*",
-        "tiny-relative-date": "*",
-        "treeverse": "*",
-        "validate-npm-package-name": "*",
-        "which": "*",
-        "write-file-atomic": "*"
-      },
-      "bin": {
-        "npm": "bin/npm-cli.js",
-        "npx": "bin/npx-cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/@gar/promisify": {
-      "version": "1.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/@isaacs/string-locale-compare": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "2.9.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/string-locale-compare": "^1.0.1",
-        "@npmcli/installed-package-contents": "^1.0.7",
-        "@npmcli/map-workspaces": "^1.0.2",
-        "@npmcli/metavuln-calculator": "^1.1.0",
-        "@npmcli/move-file": "^1.1.0",
-        "@npmcli/name-from-folder": "^1.0.1",
-        "@npmcli/node-gyp": "^1.0.1",
-        "@npmcli/package-json": "^1.0.1",
-        "@npmcli/run-script": "^1.8.2",
-        "bin-links": "^2.2.1",
-        "cacache": "^15.0.3",
-        "common-ancestor-path": "^1.0.1",
-        "json-parse-even-better-errors": "^2.3.1",
-        "json-stringify-nice": "^1.1.4",
-        "mkdirp": "^1.0.4",
-        "mkdirp-infer-owner": "^2.0.0",
-        "npm-install-checks": "^4.0.0",
-        "npm-package-arg": "^8.1.5",
-        "npm-pick-manifest": "^6.1.0",
-        "npm-registry-fetch": "^11.0.0",
-        "pacote": "^11.3.5",
-        "parse-conflict-json": "^1.1.1",
-        "proc-log": "^1.0.0",
-        "promise-all-reject-late": "^1.0.0",
-        "promise-call-limit": "^1.0.1",
-        "read-package-json-fast": "^2.0.2",
-        "readdir-scoped-modules": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "ssri": "^8.0.1",
-        "treeverse": "^1.0.4",
-        "walk-up-path": "^1.0.0"
-      },
-      "bin": {
-        "arborist": "bin/index.js"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/@npmcli/ci-detect": {
-      "version": "1.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/@npmcli/config": {
-      "version": "2.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "ini": "^2.0.0",
-        "mkdirp-infer-owner": "^2.0.0",
-        "nopt": "^5.0.0",
-        "semver": "^7.3.4",
-        "walk-up-path": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/@npmcli/disparity-colors": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "ansi-styles": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/@npmcli/fs": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@gar/promisify": "^1.0.1",
-        "semver": "^7.3.5"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/@npmcli/git": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/promise-spawn": "^1.3.2",
-        "lru-cache": "^6.0.0",
-        "mkdirp": "^1.0.4",
-        "npm-pick-manifest": "^6.1.1",
-        "promise-inflight": "^1.0.1",
-        "promise-retry": "^2.0.1",
-        "semver": "^7.3.5",
-        "which": "^2.0.2"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-      "version": "1.0.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-bundled": "^1.1.1",
-        "npm-normalize-package-bin": "^1.0.1"
-      },
-      "bin": {
-        "installed-package-contents": "index.js"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/name-from-folder": "^1.0.1",
-        "glob": "^7.1.6",
-        "minimatch": "^3.0.4",
-        "read-package-json-fast": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "1.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cacache": "^15.0.5",
-        "pacote": "^11.1.11",
-        "semver": "^7.3.2"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/@npmcli/move-file": {
-      "version": "1.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/@npmcli/name-from-folder": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/@npmcli/node-gyp": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^2.3.1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/@npmcli/promise-spawn": {
-      "version": "1.3.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "infer-owner": "^1.0.4"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "1.8.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/node-gyp": "^1.0.2",
-        "@npmcli/promise-spawn": "^1.3.2",
-        "node-gyp": "^7.1.0",
-        "read-package-json-fast": "^2.0.1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/abbrev": {
-      "version": "1.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/agent-base": {
-      "version": "6.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/agentkeepalive": {
-      "version": "4.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.0",
-        "depd": "^1.1.2",
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/ajv": {
-      "version": "6.12.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/ansicolors": {
-      "version": "0.3.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/ansistyles": {
-      "version": "0.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/aproba": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/archy": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/are-we-there-yet": {
-      "version": "1.1.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/asap": {
-      "version": "2.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/asn1": {
-      "version": "0.2.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/assert-plus": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/asynckit": {
-      "version": "0.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/aws4": {
-      "version": "1.11.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/bin-links": {
-      "version": "2.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cmd-shim": "^4.0.1",
-        "mkdirp": "^1.0.3",
-        "npm-normalize-package-bin": "^1.0.0",
-        "read-cmd-shim": "^2.0.0",
-        "rimraf": "^3.0.0",
-        "write-file-atomic": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/builtins": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/cacache": {
-      "version": "15.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^1.0.0",
-        "@npmcli/move-file": "^1.0.1",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "glob": "^7.1.4",
-        "infer-owner": "^1.0.4",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.1",
-        "minipass-collect": "^1.0.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.2",
-        "mkdirp": "^1.0.3",
-        "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^8.0.1",
-        "tar": "^6.0.2",
-        "unique-filename": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/caseless": {
-      "version": "0.12.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/chalk": {
-      "version": "4.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/chownr": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/cidr-regex": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "ip-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/clean-stack": {
-      "version": "2.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/cli-columns": {
-      "version": "3.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^2.0.0",
-        "strip-ansi": "^3.0.1"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/cli-table3": {
-      "version": "0.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4.1.0",
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      },
-      "optionalDependencies": {
-        "colors": "^1.1.2"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/cli-table3/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/cli-table3/node_modules/string-width": {
-      "version": "4.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/cli-table3/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/clone": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/cmd-shim": {
-      "version": "4.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "mkdirp-infer-owner": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/code-point-at": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/color-support": {
-      "version": "1.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/colors": {
-      "version": "1.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/columnify": {
-      "version": "1.5.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "strip-ansi": "^3.0.0",
-        "wcwidth": "^1.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/combined-stream": {
-      "version": "1.0.8",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/common-ancestor-path": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/concat-map": {
-      "version": "0.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/core-util-is": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/dashdash": {
-      "version": "1.14.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/debug": {
-      "version": "4.3.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/debuglog": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/defaults": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/delegates": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/depd": {
-      "version": "1.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/dezalgo": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/diff": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/encoding": {
-      "version": "0.1.13",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/env-paths": {
-      "version": "2.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/err-code": {
-      "version": "2.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/extend": {
-      "version": "3.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/extsprintf": {
-      "version": "1.3.0",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/fastest-levenshtein": {
-      "version": "1.0.12",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/forever-agent": {
-      "version": "0.6.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/function-bind": {
-      "version": "1.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/gauge": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.2",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.1",
-        "object-assign": "^4.1.1",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1 || ^2.0.0",
-        "strip-ansi": "^3.0.1 || ^4.0.0",
-        "wide-align": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/getpass": {
-      "version": "0.1.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/glob": {
-      "version": "7.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/graceful-fs": {
-      "version": "4.2.8",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/har-schema": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/har-validator": {
-      "version": "5.1.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/has": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/has-unicode": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/hosted-git-info": {
-      "version": "4.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/http-proxy-agent": {
-      "version": "4.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/http-signature": {
-      "version": "1.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/https-proxy-agent": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/ignore-walk": {
-      "version": "3.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^3.0.4"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/indent-string": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/infer-owner": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/inflight": {
-      "version": "1.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/inherits": {
-      "version": "2.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/ini": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/init-package-json": {
-      "version": "2.0.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-package-arg": "^8.1.5",
-        "promzard": "^0.3.0",
-        "read": "~1.0.1",
-        "read-package-json": "^4.1.1",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4",
-        "validate-npm-package-name": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/ip": {
-      "version": "1.1.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/ip-regex": {
-      "version": "4.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/is-cidr": {
-      "version": "4.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "cidr-regex": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/is-core-module": {
-      "version": "2.7.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/is-lambda": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/isexe": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/isstream": {
-      "version": "0.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/jsbn": {
-      "version": "0.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/json-schema": {
-      "version": "0.2.3",
-      "dev": true,
-      "inBundle": true
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/json-stringify-nice": {
-      "version": "1.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/jsonparse": {
-      "version": "1.3.1",
-      "dev": true,
-      "engines": [
-        "node >= 0.2.0"
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/jsprim": {
-      "version": "1.4.1",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/just-diff": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/just-diff-apply": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/libnpmaccess": {
-      "version": "4.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "minipass": "^3.1.1",
-        "npm-package-arg": "^8.1.2",
-        "npm-registry-fetch": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/libnpmdiff": {
-      "version": "2.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/disparity-colors": "^1.0.1",
-        "@npmcli/installed-package-contents": "^1.0.7",
-        "binary-extensions": "^2.2.0",
-        "diff": "^5.0.0",
-        "minimatch": "^3.0.4",
-        "npm-package-arg": "^8.1.4",
-        "pacote": "^11.3.4",
-        "tar": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/libnpmexec": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^2.3.0",
-        "@npmcli/ci-detect": "^1.3.0",
-        "@npmcli/run-script": "^1.8.4",
-        "chalk": "^4.1.0",
-        "mkdirp-infer-owner": "^2.0.0",
-        "npm-package-arg": "^8.1.2",
-        "pacote": "^11.3.1",
-        "proc-log": "^1.0.0",
-        "read": "^1.0.7",
-        "read-package-json-fast": "^2.0.2",
-        "walk-up-path": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/libnpmfund": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^2.5.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/libnpmhook": {
-      "version": "6.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/libnpmorg": {
-      "version": "2.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/libnpmpack": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/run-script": "^1.8.3",
-        "npm-package-arg": "^8.1.0",
-        "pacote": "^11.2.6"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/libnpmpublish": {
-      "version": "4.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "normalize-package-data": "^3.0.2",
-        "npm-package-arg": "^8.1.2",
-        "npm-registry-fetch": "^11.0.0",
-        "semver": "^7.1.3",
-        "ssri": "^8.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/libnpmsearch": {
-      "version": "3.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/libnpmteam": {
-      "version": "2.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/libnpmversion": {
-      "version": "1.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^2.0.7",
-        "@npmcli/run-script": "^1.8.4",
-        "json-parse-even-better-errors": "^2.3.1",
-        "semver": "^7.3.5",
-        "stringify-package": "^1.0.1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "9.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "agentkeepalive": "^4.1.3",
-        "cacache": "^15.2.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.3",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^1.3.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.2",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^6.0.0",
-        "ssri": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/mime-db": {
-      "version": "1.49.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/mime-types": {
-      "version": "2.1.32",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.49.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/minimatch": {
-      "version": "3.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/minipass": {
-      "version": "3.1.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/minipass-collect": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/minipass-fetch": {
-      "version": "1.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.1.0",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.12"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/minipass-json-stream": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsonparse": "^1.3.1",
-        "minipass": "^3.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/minipass-pipeline": {
-      "version": "1.2.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/minipass-sized": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/minizlib": {
-      "version": "2.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/mkdirp-infer-owner": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "infer-owner": "^1.0.4",
-        "mkdirp": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/ms": {
-      "version": "2.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/mute-stream": {
-      "version": "0.0.8",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/negotiator": {
-      "version": "0.6.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/node-gyp": {
-      "version": "7.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.0",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.3",
-        "nopt": "^5.0.0",
-        "npmlog": "^4.1.2",
-        "request": "^2.88.2",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.2",
-        "tar": "^6.0.2",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": ">= 10.12.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/node-gyp/node_modules/aproba": {
-      "version": "1.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
-      "version": "2.7.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/node-gyp/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/node-gyp/node_modules/npmlog": {
-      "version": "4.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/node-gyp/node_modules/string-width": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/nopt": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/normalize-package-data": {
-      "version": "3.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^4.0.1",
-        "is-core-module": "^2.5.0",
-        "semver": "^7.3.4",
-        "validate-npm-package-license": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/npm-audit-report": {
-      "version": "2.1.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/npm-bundled": {
-      "version": "1.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-normalize-package-bin": "^1.0.1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/npm-install-checks": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "semver": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/npm-normalize-package-bin": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/npm-package-arg": {
-      "version": "8.1.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "hosted-git-info": "^4.0.1",
-        "semver": "^7.3.4",
-        "validate-npm-package-name": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/npm-packlist": {
-      "version": "2.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.6",
-        "ignore-walk": "^3.0.3",
-        "npm-bundled": "^1.1.1",
-        "npm-normalize-package-bin": "^1.0.1"
-      },
-      "bin": {
-        "npm-packlist": "bin/index.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/npm-pick-manifest": {
-      "version": "6.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-install-checks": "^4.0.0",
-        "npm-normalize-package-bin": "^1.0.1",
-        "npm-package-arg": "^8.1.2",
-        "semver": "^7.3.4"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/npm-profile": {
-      "version": "5.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "11.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "make-fetch-happen": "^9.0.1",
-        "minipass": "^3.1.3",
-        "minipass-fetch": "^1.3.0",
-        "minipass-json-stream": "^1.0.1",
-        "minizlib": "^2.0.0",
-        "npm-package-arg": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/npm-user-validate": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/npmlog": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "^2.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^3.0.0",
-        "set-blocking": "^2.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/npmlog/node_modules/are-we-there-yet": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/object-assign": {
-      "version": "4.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/once": {
-      "version": "1.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/opener": {
-      "version": "1.5.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "(WTFPL OR MIT)",
-      "bin": {
-        "opener": "bin/opener-bin.js"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/p-map": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/pacote": {
-      "version": "11.3.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^2.1.0",
-        "@npmcli/installed-package-contents": "^1.0.6",
-        "@npmcli/promise-spawn": "^1.2.0",
-        "@npmcli/run-script": "^1.8.2",
-        "cacache": "^15.0.5",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.1.0",
-        "infer-owner": "^1.0.4",
-        "minipass": "^3.1.3",
-        "mkdirp": "^1.0.3",
-        "npm-package-arg": "^8.0.1",
-        "npm-packlist": "^2.1.4",
-        "npm-pick-manifest": "^6.0.0",
-        "npm-registry-fetch": "^11.0.0",
-        "promise-retry": "^2.0.1",
-        "read-package-json-fast": "^2.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^8.0.1",
-        "tar": "^6.1.0"
-      },
-      "bin": {
-        "pacote": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/parse-conflict-json": {
-      "version": "1.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^2.3.0",
-        "just-diff": "^3.0.1",
-        "just-diff-apply": "^3.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/performance-now": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/proc-log": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/promise-all-reject-late": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/promise-call-limit": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/promise-inflight": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/promise-retry": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/promzard": {
-      "version": "0.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "read": "1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/psl": {
-      "version": "1.8.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/punycode": {
-      "version": "2.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/qrcode-terminal": {
-      "version": "0.12.0",
-      "dev": true,
-      "inBundle": true,
-      "bin": {
-        "qrcode-terminal": "bin/qrcode-terminal.js"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/qs": {
-      "version": "6.5.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/read": {
-      "version": "1.0.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "mute-stream": "~0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/read-cmd-shim": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/read-package-json": {
-      "version": "4.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "normalize-package-data": "^3.0.0",
-        "npm-normalize-package-bin": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/read-package-json-fast": {
-      "version": "2.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^2.3.0",
-        "npm-normalize-package-bin": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/readdir-scoped-modules": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "debuglog": "^1.0.1",
-        "dezalgo": "^1.0.0",
-        "graceful-fs": "^4.1.2",
-        "once": "^1.3.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/request": {
-      "version": "2.88.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/request/node_modules/form-data": {
-      "version": "2.3.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/request/node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/rimraf": {
-      "version": "3.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/semver": {
-      "version": "7.3.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/set-blocking": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/signal-exit": {
-      "version": "3.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/socks": {
-      "version": "2.6.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ip": "^1.1.5",
-        "smart-buffer": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/socks-proxy-agent": {
-      "version": "6.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.1",
-        "socks": "^2.6.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/spdx-correct": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/spdx-exceptions": {
-      "version": "2.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "CC-BY-3.0"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.10",
-      "dev": true,
-      "inBundle": true,
-      "license": "CC0-1.0"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/sshpk": {
-      "version": "1.16.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/ssri": {
-      "version": "8.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/string-width": {
-      "version": "2.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/string-width/node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/string-width/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/stringify-package": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/tar": {
-      "version": "6.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/text-table": {
-      "version": "0.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/tiny-relative-date": {
-      "version": "1.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/treeverse": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "Unlicense"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/typedarray-to-buffer": {
-      "version": "3.1.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/unique-filename": {
-      "version": "1.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^2.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/unique-slug": {
-      "version": "2.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/uri-js": {
-      "version": "4.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/uuid": {
-      "version": "3.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "builtins": "^1.0.3"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/verror": {
-      "version": "1.10.0",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/walk-up-path": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/wcwidth": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/wide-align": {
-      "version": "1.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/wrappy": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/write-file-atomic": {
-      "version": "3.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/npm/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/p-reduce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
-      "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/registry-auth-token": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.2.tgz",
-      "integrity": "sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==",
-      "dev": true,
-      "dependencies": {
-        "rc": "1.2.8"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release": {
-      "version": "19.0.5",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.5.tgz",
-      "integrity": "sha512-NMPKdfpXTnPn49FDogMBi36SiBfXkSOJqCkk0E4iWOY1tusvvgBwqUmxTX1kmlT6kIYed9YwNKD1sfPpqa5yaA==",
-      "dev": true,
-      "dependencies": {
-        "@semantic-release/commit-analyzer": "^9.0.2",
-        "@semantic-release/error": "^3.0.0",
-        "@semantic-release/github": "^8.0.0",
-        "@semantic-release/npm": "^9.0.0",
-        "@semantic-release/release-notes-generator": "^10.0.0",
-        "aggregate-error": "^3.0.0",
-        "cosmiconfig": "^7.0.0",
-        "debug": "^4.0.0",
-        "env-ci": "^5.0.0",
-        "execa": "^5.0.0",
-        "figures": "^3.0.0",
-        "find-versions": "^4.0.0",
-        "get-stream": "^6.0.0",
-        "git-log-parser": "^1.2.0",
-        "hook-std": "^2.0.0",
-        "hosted-git-info": "^4.0.0",
-        "lodash": "^4.17.21",
-        "marked": "^4.0.10",
-        "marked-terminal": "^5.0.0",
-        "micromatch": "^4.0.2",
-        "p-each-series": "^2.1.0",
-        "p-reduce": "^2.0.0",
-        "read-pkg-up": "^7.0.0",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.3.2",
-        "semver-diff": "^3.1.1",
-        "signale": "^1.2.1",
-        "yargs": "^16.2.0"
-      },
-      "bin": {
-        "semantic-release": "bin/semantic-release.js"
-      },
-      "engines": {
-        "node": ">=16 || ^14.17"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/@semantic-release/npm": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.2.tgz",
-      "integrity": "sha512-zgsynF6McdzxPnFet+a4iO9HpAlARXOM5adz7VGVCvj0ne8wtL2ZOQoDV2wZPDmdEotDIbVeJjafhelZjs9j6g==",
-      "dev": true,
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "execa": "^5.0.0",
-        "fs-extra": "^11.0.0",
-        "lodash": "^4.17.15",
-        "nerf-dart": "^1.0.0",
-        "normalize-url": "^6.0.0",
-        "npm": "^8.3.0",
-        "rc": "^1.2.8",
-        "read-pkg": "^5.0.0",
-        "registry-auth-token": "^5.0.0",
-        "semver": "^7.1.2",
-        "tempy": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16 || ^14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=19.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/fs-extra": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
-      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm": {
-      "version": "8.19.4",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.4.tgz",
-      "integrity": "sha512-3HANl8i9DKnUA89P4KEgVNN28EjSeDCmvEqbzOAuxCFDzdBZzjUl99zgnGpOUumvW5lvJo2HKcjrsc+tfyv1Hw==",
-      "bundleDependencies": [
-        "@isaacs/string-locale-compare",
-        "@npmcli/arborist",
-        "@npmcli/ci-detect",
-        "@npmcli/config",
-        "@npmcli/fs",
-        "@npmcli/map-workspaces",
-        "@npmcli/package-json",
-        "@npmcli/run-script",
-        "abbrev",
-        "archy",
-        "cacache",
-        "chalk",
-        "chownr",
-        "cli-columns",
-        "cli-table3",
-        "columnify",
-        "fastest-levenshtein",
-        "fs-minipass",
-        "glob",
-        "graceful-fs",
-        "hosted-git-info",
-        "ini",
-        "init-package-json",
-        "is-cidr",
-        "json-parse-even-better-errors",
-        "libnpmaccess",
-        "libnpmdiff",
-        "libnpmexec",
-        "libnpmfund",
-        "libnpmhook",
-        "libnpmorg",
-        "libnpmpack",
-        "libnpmpublish",
-        "libnpmsearch",
-        "libnpmteam",
-        "libnpmversion",
-        "make-fetch-happen",
-        "minimatch",
-        "minipass",
-        "minipass-pipeline",
-        "mkdirp",
-        "mkdirp-infer-owner",
-        "ms",
-        "node-gyp",
-        "nopt",
-        "npm-audit-report",
-        "npm-install-checks",
-        "npm-package-arg",
-        "npm-pick-manifest",
-        "npm-profile",
-        "npm-registry-fetch",
-        "npm-user-validate",
-        "npmlog",
-        "opener",
-        "p-map",
-        "pacote",
-        "parse-conflict-json",
-        "proc-log",
-        "qrcode-terminal",
-        "read",
-        "read-package-json",
-        "read-package-json-fast",
-        "readdir-scoped-modules",
-        "rimraf",
-        "semver",
-        "ssri",
-        "tar",
-        "text-table",
-        "tiny-relative-date",
-        "treeverse",
-        "validate-npm-package-name",
-        "which",
-        "write-file-atomic"
-      ],
-      "dev": true,
-      "dependencies": {
-        "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^5.6.3",
-        "@npmcli/ci-detect": "^2.0.0",
-        "@npmcli/config": "^4.2.1",
-        "@npmcli/fs": "^2.1.0",
-        "@npmcli/map-workspaces": "^2.0.3",
-        "@npmcli/package-json": "^2.0.0",
-        "@npmcli/run-script": "^4.2.1",
-        "abbrev": "~1.1.1",
-        "archy": "~1.0.0",
-        "cacache": "^16.1.3",
-        "chalk": "^4.1.2",
-        "chownr": "^2.0.0",
-        "cli-columns": "^4.0.0",
-        "cli-table3": "^0.6.2",
-        "columnify": "^1.6.0",
-        "fastest-levenshtein": "^1.0.12",
-        "fs-minipass": "^2.1.0",
-        "glob": "^8.0.1",
-        "graceful-fs": "^4.2.10",
-        "hosted-git-info": "^5.2.1",
-        "ini": "^3.0.1",
-        "init-package-json": "^3.0.2",
-        "is-cidr": "^4.0.2",
-        "json-parse-even-better-errors": "^2.3.1",
-        "libnpmaccess": "^6.0.4",
-        "libnpmdiff": "^4.0.5",
-        "libnpmexec": "^4.0.14",
-        "libnpmfund": "^3.0.5",
-        "libnpmhook": "^8.0.4",
-        "libnpmorg": "^4.0.4",
-        "libnpmpack": "^4.1.3",
-        "libnpmpublish": "^6.0.5",
-        "libnpmsearch": "^5.0.4",
-        "libnpmteam": "^4.0.4",
-        "libnpmversion": "^3.0.7",
-        "make-fetch-happen": "^10.2.0",
-        "minimatch": "^5.1.0",
-        "minipass": "^3.1.6",
-        "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "mkdirp-infer-owner": "^2.0.0",
-        "ms": "^2.1.2",
-        "node-gyp": "^9.1.0",
-        "nopt": "^6.0.0",
-        "npm-audit-report": "^3.0.0",
-        "npm-install-checks": "^5.0.0",
-        "npm-package-arg": "^9.1.0",
-        "npm-pick-manifest": "^7.0.2",
-        "npm-profile": "^6.2.0",
-        "npm-registry-fetch": "^13.3.1",
-        "npm-user-validate": "^1.0.1",
-        "npmlog": "^6.0.2",
-        "opener": "^1.5.2",
-        "p-map": "^4.0.0",
-        "pacote": "^13.6.2",
-        "parse-conflict-json": "^2.0.2",
-        "proc-log": "^2.0.1",
-        "qrcode-terminal": "^0.12.0",
-        "read": "~1.0.7",
-        "read-package-json": "^5.0.2",
-        "read-package-json-fast": "^2.0.3",
-        "readdir-scoped-modules": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.7",
-        "ssri": "^9.0.1",
-        "tar": "^6.1.11",
-        "text-table": "~0.2.0",
-        "tiny-relative-date": "^1.3.0",
-        "treeverse": "^2.0.0",
-        "validate-npm-package-name": "^4.0.0",
-        "which": "^2.0.2",
-        "write-file-atomic": "^4.0.1"
-      },
-      "bin": {
-        "npm": "bin/npm-cli.js",
-        "npx": "bin/npx-cli.js"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@gar/promisify": {
-      "version": "1.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@isaacs/string-locale-compare": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "5.6.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/installed-package-contents": "^1.0.7",
-        "@npmcli/map-workspaces": "^2.0.3",
-        "@npmcli/metavuln-calculator": "^3.0.1",
-        "@npmcli/move-file": "^2.0.0",
-        "@npmcli/name-from-folder": "^1.0.1",
-        "@npmcli/node-gyp": "^2.0.0",
-        "@npmcli/package-json": "^2.0.0",
-        "@npmcli/query": "^1.2.0",
-        "@npmcli/run-script": "^4.1.3",
-        "bin-links": "^3.0.3",
-        "cacache": "^16.1.3",
-        "common-ancestor-path": "^1.0.1",
-        "hosted-git-info": "^5.2.1",
-        "json-parse-even-better-errors": "^2.3.1",
-        "json-stringify-nice": "^1.1.4",
-        "minimatch": "^5.1.0",
-        "mkdirp": "^1.0.4",
-        "mkdirp-infer-owner": "^2.0.0",
-        "nopt": "^6.0.0",
-        "npm-install-checks": "^5.0.0",
-        "npm-package-arg": "^9.0.0",
-        "npm-pick-manifest": "^7.0.2",
-        "npm-registry-fetch": "^13.0.0",
-        "npmlog": "^6.0.2",
-        "pacote": "^13.6.1",
-        "parse-conflict-json": "^2.0.1",
-        "proc-log": "^2.0.0",
-        "promise-all-reject-late": "^1.0.0",
-        "promise-call-limit": "^1.0.1",
-        "read-package-json-fast": "^2.0.2",
-        "readdir-scoped-modules": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.7",
-        "ssri": "^9.0.0",
-        "treeverse": "^2.0.0",
-        "walk-up-path": "^1.0.0"
-      },
-      "bin": {
-        "arborist": "bin/index.js"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/ci-detect": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/config": {
-      "version": "4.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/map-workspaces": "^2.0.2",
-        "ini": "^3.0.0",
-        "mkdirp-infer-owner": "^2.0.0",
-        "nopt": "^6.0.0",
-        "proc-log": "^2.0.0",
-        "read-package-json-fast": "^2.0.3",
-        "semver": "^7.3.5",
-        "walk-up-path": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/disparity-colors": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "ansi-styles": "^4.3.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/fs": {
-      "version": "2.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@gar/promisify": "^1.1.3",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/git": {
-      "version": "3.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/promise-spawn": "^3.0.0",
-        "lru-cache": "^7.4.4",
-        "mkdirp": "^1.0.4",
-        "npm-pick-manifest": "^7.0.0",
-        "proc-log": "^2.0.0",
-        "promise-inflight": "^1.0.1",
-        "promise-retry": "^2.0.1",
-        "semver": "^7.3.5",
-        "which": "^2.0.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-      "version": "1.0.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-bundled": "^1.1.1",
-        "npm-normalize-package-bin": "^1.0.1"
-      },
-      "bin": {
-        "installed-package-contents": "index.js"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/installed-package-contents/node_modules/npm-bundled": {
-      "version": "1.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-normalize-package-bin": "^1.0.1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "2.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/name-from-folder": "^1.0.1",
-        "glob": "^8.0.1",
-        "minimatch": "^5.0.1",
-        "read-package-json-fast": "^2.0.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cacache": "^16.0.0",
-        "json-parse-even-better-errors": "^2.3.1",
-        "pacote": "^13.0.3",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/move-file": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/name-from-folder": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/node-gyp": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^2.3.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/promise-spawn": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "infer-owner": "^1.0.4"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/query": {
-      "version": "1.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-package-arg": "^9.1.0",
-        "postcss-selector-parser": "^6.0.10",
-        "semver": "^7.3.7"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "4.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/node-gyp": "^2.0.0",
-        "@npmcli/promise-spawn": "^3.0.0",
-        "node-gyp": "^9.0.0",
-        "read-package-json-fast": "^2.0.3",
-        "which": "^2.0.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/abbrev": {
-      "version": "1.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/agent-base": {
-      "version": "6.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/agentkeepalive": {
-      "version": "4.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.0",
-        "depd": "^1.1.2",
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/aproba": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/archy": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/are-we-there-yet": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/asap": {
-      "version": "2.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/bin-links": {
-      "version": "3.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cmd-shim": "^5.0.0",
-        "mkdirp-infer-owner": "^2.0.0",
-        "npm-normalize-package-bin": "^2.0.0",
-        "read-cmd-shim": "^3.0.0",
-        "rimraf": "^3.0.0",
-        "write-file-atomic": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/bin-links/node_modules/npm-normalize-package-bin": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/builtins": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/cacache": {
-      "version": "16.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^2.1.0",
-        "@npmcli/move-file": "^2.0.0",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.1.0",
-        "glob": "^8.0.1",
-        "infer-owner": "^1.0.4",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^9.0.0",
-        "tar": "^6.1.11",
-        "unique-filename": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/chalk": {
-      "version": "4.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/chownr": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/cidr-regex": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "ip-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/clean-stack": {
-      "version": "2.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/cli-columns": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/cli-table3": {
-      "version": "0.6.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      },
-      "optionalDependencies": {
-        "@colors/colors": "1.5.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/clone": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/cmd-shim": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "mkdirp-infer-owner": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/color-support": {
-      "version": "1.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/columnify": {
-      "version": "1.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "strip-ansi": "^6.0.1",
-        "wcwidth": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/common-ancestor-path": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/concat-map": {
-      "version": "0.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/cssesc": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/debug": {
-      "version": "4.3.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/debuglog": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/defaults": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/delegates": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/depd": {
-      "version": "1.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/dezalgo": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/diff": {
-      "version": "5.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/encoding": {
-      "version": "0.1.13",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/env-paths": {
-      "version": "2.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/err-code": {
-      "version": "2.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/fastest-levenshtein": {
-      "version": "1.0.12",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/function-bind": {
-      "version": "1.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/gauge": {
-      "version": "4.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^3.0.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/glob": {
-      "version": "8.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/has": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/has-unicode": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/hosted-git-info": {
-      "version": "5.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^7.5.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/http-cache-semantics": {
-      "version": "4.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/ignore-walk": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/indent-string": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/infer-owner": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/inflight": {
-      "version": "1.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/inherits": {
-      "version": "2.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/ini": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/init-package-json": {
-      "version": "3.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-package-arg": "^9.0.1",
-        "promzard": "^0.3.0",
-        "read": "^1.0.7",
-        "read-package-json": "^5.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4",
-        "validate-npm-package-name": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/ip": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/ip-regex": {
-      "version": "4.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/is-cidr": {
-      "version": "4.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "cidr-regex": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/is-core-module": {
-      "version": "2.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/is-lambda": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/isexe": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/json-stringify-nice": {
-      "version": "1.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/jsonparse": {
-      "version": "1.3.1",
-      "dev": true,
-      "engines": [
-        "node >= 0.2.0"
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/just-diff": {
-      "version": "5.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/just-diff-apply": {
-      "version": "5.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/libnpmaccess": {
-      "version": "6.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "minipass": "^3.1.1",
-        "npm-package-arg": "^9.0.1",
-        "npm-registry-fetch": "^13.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/libnpmdiff": {
-      "version": "4.0.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/disparity-colors": "^2.0.0",
-        "@npmcli/installed-package-contents": "^1.0.7",
-        "binary-extensions": "^2.2.0",
-        "diff": "^5.1.0",
-        "minimatch": "^5.0.1",
-        "npm-package-arg": "^9.0.1",
-        "pacote": "^13.6.1",
-        "tar": "^6.1.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/libnpmexec": {
-      "version": "4.0.14",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^5.6.3",
-        "@npmcli/ci-detect": "^2.0.0",
-        "@npmcli/fs": "^2.1.1",
-        "@npmcli/run-script": "^4.2.0",
-        "chalk": "^4.1.0",
-        "mkdirp-infer-owner": "^2.0.0",
-        "npm-package-arg": "^9.0.1",
-        "npmlog": "^6.0.2",
-        "pacote": "^13.6.1",
-        "proc-log": "^2.0.0",
-        "read": "^1.0.7",
-        "read-package-json-fast": "^2.0.2",
-        "semver": "^7.3.7",
-        "walk-up-path": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/libnpmfund": {
-      "version": "3.0.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^5.6.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/libnpmhook": {
-      "version": "8.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^13.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/libnpmorg": {
-      "version": "4.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^13.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/libnpmpack": {
-      "version": "4.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/run-script": "^4.1.3",
-        "npm-package-arg": "^9.0.1",
-        "pacote": "^13.6.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/libnpmpublish": {
-      "version": "6.0.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "normalize-package-data": "^4.0.0",
-        "npm-package-arg": "^9.0.1",
-        "npm-registry-fetch": "^13.0.0",
-        "semver": "^7.3.7",
-        "ssri": "^9.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/libnpmsearch": {
-      "version": "5.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^13.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/libnpmteam": {
-      "version": "4.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^13.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/libnpmversion": {
-      "version": "3.0.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^3.0.0",
-        "@npmcli/run-script": "^4.1.3",
-        "json-parse-even-better-errors": "^2.3.1",
-        "proc-log": "^2.0.0",
-        "semver": "^7.3.7"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/lru-cache": {
-      "version": "7.13.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "10.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "agentkeepalive": "^4.2.1",
-        "cacache": "^16.1.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^2.0.3",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.3",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^7.0.0",
-        "ssri": "^9.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/minimatch": {
-      "version": "5.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/minipass": {
-      "version": "3.3.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/minipass-collect": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/minipass-fetch": {
-      "version": "2.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.1.6",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.1.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.13"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/minipass-json-stream": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsonparse": "^1.3.1",
-        "minipass": "^3.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/minipass-pipeline": {
-      "version": "1.2.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/minipass-sized": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/minizlib": {
-      "version": "2.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/mkdirp-infer-owner": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "infer-owner": "^1.0.4",
-        "mkdirp": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/ms": {
-      "version": "2.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/mute-stream": {
-      "version": "0.0.8",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/negotiator": {
-      "version": "0.6.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/node-gyp": {
-      "version": "9.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.0",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^10.0.3",
-        "nopt": "^5.0.0",
-        "npmlog": "^6.0.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.2",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": "^12.22 || ^14.13 || >=16"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/node-gyp/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/nopt": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "^1.0.0"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/normalize-package-data": {
-      "version": "4.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^5.0.0",
-        "is-core-module": "^2.8.1",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/npm-audit-report": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/npm-bundled": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-normalize-package-bin": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/npm-bundled/node_modules/npm-normalize-package-bin": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/npm-install-checks": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "semver": "^7.1.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/npm-normalize-package-bin": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/npm-package-arg": {
-      "version": "9.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "hosted-git-info": "^5.0.0",
-        "proc-log": "^2.0.1",
-        "semver": "^7.3.5",
-        "validate-npm-package-name": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/npm-packlist": {
-      "version": "5.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^8.0.1",
-        "ignore-walk": "^5.0.1",
-        "npm-bundled": "^2.0.0",
-        "npm-normalize-package-bin": "^2.0.0"
-      },
-      "bin": {
-        "npm-packlist": "bin/index.js"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/npm-packlist/node_modules/npm-normalize-package-bin": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/npm-pick-manifest": {
-      "version": "7.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-install-checks": "^5.0.0",
-        "npm-normalize-package-bin": "^2.0.0",
-        "npm-package-arg": "^9.0.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/npm-profile": {
-      "version": "6.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^13.0.1",
-        "proc-log": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "13.3.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "make-fetch-happen": "^10.0.6",
-        "minipass": "^3.1.6",
-        "minipass-fetch": "^2.0.3",
-        "minipass-json-stream": "^1.0.1",
-        "minizlib": "^2.1.2",
-        "npm-package-arg": "^9.0.1",
-        "proc-log": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/npm-user-validate": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/npmlog": {
-      "version": "6.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "^3.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^4.0.3",
-        "set-blocking": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/once": {
-      "version": "1.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/opener": {
-      "version": "1.5.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "(WTFPL OR MIT)",
-      "bin": {
-        "opener": "bin/opener-bin.js"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/p-map": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/pacote": {
-      "version": "13.6.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^3.0.0",
-        "@npmcli/installed-package-contents": "^1.0.7",
-        "@npmcli/promise-spawn": "^3.0.0",
-        "@npmcli/run-script": "^4.1.0",
-        "cacache": "^16.0.0",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.1.0",
-        "infer-owner": "^1.0.4",
-        "minipass": "^3.1.6",
-        "mkdirp": "^1.0.4",
-        "npm-package-arg": "^9.0.0",
-        "npm-packlist": "^5.1.0",
-        "npm-pick-manifest": "^7.0.0",
-        "npm-registry-fetch": "^13.0.1",
-        "proc-log": "^2.0.0",
-        "promise-retry": "^2.0.1",
-        "read-package-json": "^5.0.0",
-        "read-package-json-fast": "^2.0.3",
-        "rimraf": "^3.0.2",
-        "ssri": "^9.0.0",
-        "tar": "^6.1.11"
-      },
-      "bin": {
-        "pacote": "lib/bin.js"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/parse-conflict-json": {
-      "version": "2.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^2.3.1",
-        "just-diff": "^5.0.1",
-        "just-diff-apply": "^5.2.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "6.0.10",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/proc-log": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/promise-all-reject-late": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/promise-call-limit": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/promise-inflight": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/promise-retry": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/promzard": {
-      "version": "0.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "read": "1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/qrcode-terminal": {
-      "version": "0.12.0",
-      "dev": true,
-      "inBundle": true,
-      "bin": {
-        "qrcode-terminal": "bin/qrcode-terminal.js"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/read": {
-      "version": "1.0.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "mute-stream": "~0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/read-cmd-shim": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/read-package-json": {
-      "version": "5.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^8.0.1",
-        "json-parse-even-better-errors": "^2.3.1",
-        "normalize-package-data": "^4.0.0",
-        "npm-normalize-package-bin": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/read-package-json-fast": {
-      "version": "2.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^2.3.0",
-        "npm-normalize-package-bin": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/read-package-json/node_modules/npm-normalize-package-bin": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/readdir-scoped-modules": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "debuglog": "^1.0.1",
-        "dezalgo": "^1.0.0",
-        "graceful-fs": "^4.1.2",
-        "once": "^1.3.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/rimraf": {
-      "version": "3.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/semver": {
-      "version": "7.3.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/set-blocking": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/socks": {
-      "version": "2.7.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ip": "^2.0.0",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/socks-proxy-agent": {
-      "version": "7.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.3",
-        "socks": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/spdx-correct": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/spdx-exceptions": {
-      "version": "2.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "CC-BY-3.0"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "CC0-1.0"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/ssri": {
-      "version": "9.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.1.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/string-width": {
-      "version": "4.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/tar": {
-      "version": "6.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/text-table": {
-      "version": "0.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/tiny-relative-date": {
-      "version": "1.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/treeverse": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/unique-filename": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/unique-slug": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "builtins": "^5.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/walk-up-path": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/wcwidth": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/wide-align": {
-      "version": "1.1.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/wrappy": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/write-file-atomic": {
-      "version": "4.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.7"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/npm/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semantic-release/node_modules/registry-auth-token": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
-      "integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
-      "dev": true,
-      "dependencies": {
-        "@pnpm/npm-conf": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semver-diff": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
-      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semver-diff/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/semver-regex": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
-      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/tempy": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
-      "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
-      "dev": true,
-      "dependencies": {
-        "del": "^6.0.0",
-        "is-stream": "^2.0.0",
-        "temp-dir": "^2.0.0",
-        "type-fest": "^0.16.0",
-        "unique-string": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/type-fest": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
-      "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/unique-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-      "dev": true,
-      "dependencies": {
-        "crypto-random-string": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/semantic-release-npm-github-publish/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
+        "@semantic-release/changelog": ">=6.0.0",
+        "@semantic-release/commit-analyzer": ">=9.0.0",
+        "@semantic-release/git": ">=10.0.0",
+        "@semantic-release/github": ">=8.0.0",
+        "@semantic-release/npm": ">=9.0.0",
+        "@semantic-release/release-notes-generator": ">=10.0.0",
+        "semantic-release": ">=20.0.0"
       }
     },
     "node_modules/semantic-release/node_modules/@octokit/auth-token": {
@@ -29083,12 +21267,6 @@
         "semver": "bin/semver"
       }
     },
-    "node_modules/semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "dev": true
-    },
     "node_modules/semver-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-4.0.0.tgz",
@@ -29126,33 +21304,6 @@
       "dev": true,
       "engines": {
         "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/serialize-error": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/serialize-error/node_modules/type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -29280,23 +21431,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/snyk": {
-      "version": "1.1115.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1115.0.tgz",
-      "integrity": "sha512-CTOwrt1qx+59cMRe+TsIg4SA4g/qZTNTw0KqVXNx/ta6SNLKx0XSwNMibMqDq++eb5IJzyNKCnlU0FtFrUo4hw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@sentry/node": "^7.36.0",
-        "global-agent": "^3.0.0"
-      },
-      "bin": {
-        "snyk": "bin/snyk"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -29353,18 +21487,6 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
       "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
       "dev": true
-    },
-    "node_modules/split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "dev": true,
-      "dependencies": {
-        "through": "2"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/split2": {
       "version": "3.2.2",
@@ -30378,12 +22500,6 @@
         "querystring": "0.2.0"
       }
     },
-    "node_modules/url-join": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-      "dev": true
-    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -30713,9 +22829,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
       "engines": {
         "node": ">=8.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -50,12 +50,18 @@
   ],
   "dependencies": {
     "@aws-sdk/client-kms": "^3.391.0",
+    "@ethersproject/abstract-provider": "^5.7.0",
+    "@ethersproject/abstract-signer": "^5.7.0",
+    "@ethersproject/bytes": "^5.7.0",
+    "@ethersproject/hash": "^5.7.0",
+    "@ethersproject/keccak256": "^5.7.0",
+    "@ethersproject/properties": "^5.7.0",
+    "@ethersproject/transactions": "^5.7.0",
     "@types/node": "^18.14.6",
     "asn1.js": "^5.4.1",
     "aws-sdk": "^2.1438.0",
     "bn.js": "^5.2.1",
-    "debug": "^4.3.4",
-    "ethers": "^5.4.7"
+    "debug": "^4.3.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.21.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
-import { UnsignedTransaction } from "ethers";
 import { arrayify, Bytes, joinSignature } from "@ethersproject/bytes";
 import { Signer } from "@ethersproject/abstract-signer";
 import { Provider, TransactionRequest } from "@ethersproject/abstract-provider";
 import { Deferrable, defineReadOnly, resolveProperties } from "@ethersproject/properties";
 import { keccak256 } from "@ethersproject/keccak256";
-import { serialize as serializeTransaction } from "@ethersproject/transactions";
+import { serialize as serializeTransaction, UnsignedTransaction } from "@ethersproject/transactions";
 
 import { hashMessage } from "@ethersproject/hash";
 import { getPublicKey, getEthereumAddress, requestKmsSignature, determineCorrectV } from "./util/aws-kms-utils";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,12 @@
-import { ethers, UnsignedTransaction } from "ethers";
+import { UnsignedTransaction } from "ethers";
+import { arrayify, Bytes, joinSignature } from "@ethersproject/bytes";
+import { Signer } from "@ethersproject/abstract-signer";
+import { Provider, TransactionRequest } from "@ethersproject/abstract-provider";
+import { Deferrable, defineReadOnly, resolveProperties } from "@ethersproject/properties";
+import { keccak256 } from "@ethersproject/keccak256";
+import { serialize as serializeTransaction } from "@ethersproject/transactions";
+
+import { hashMessage } from "@ethersproject/hash";
 import { getPublicKey, getEthereumAddress, requestKmsSignature, determineCorrectV } from "./util/aws-kms-utils";
 
 export interface AwsKmsSignerCredentials {
@@ -8,15 +16,15 @@ export interface AwsKmsSignerCredentials {
   region: string;
   keyId: string;
 }
-export class AwsKmsSigner extends ethers.Signer {
+export class AwsKmsSigner extends Signer {
   kmsCredentials: AwsKmsSignerCredentials;
 
   ethereumAddress: string;
 
-  constructor(kmsCredentials: AwsKmsSignerCredentials, provider?: ethers.providers.Provider) {
+  constructor(kmsCredentials: AwsKmsSignerCredentials, provider?: Provider) {
     super();
-    ethers.utils.defineReadOnly(this, "provider", provider || null);
-    ethers.utils.defineReadOnly(this, "kmsCredentials", kmsCredentials);
+    defineReadOnly(this, "provider", provider || null);
+    defineReadOnly(this, "kmsCredentials", kmsCredentials);
   }
 
   async getAddress(): Promise<string> {
@@ -28,29 +36,29 @@ export class AwsKmsSigner extends ethers.Signer {
   }
 
   async _signDigest(digestString: string): Promise<string> {
-    const digestBuffer = Buffer.from(ethers.utils.arrayify(digestString));
+    const digestBuffer = Buffer.from(arrayify(digestString));
     const sig = await requestKmsSignature(digestBuffer, this.kmsCredentials);
     const ethAddr = await this.getAddress();
     const { v } = determineCorrectV(digestBuffer, sig.r, sig.s, ethAddr);
-    return ethers.utils.joinSignature({
+    return joinSignature({
       v,
       r: `0x${sig.r.toString("hex")}`,
       s: `0x${sig.s.toString("hex")}`,
     });
   }
 
-  async signMessage(message: string | ethers.utils.Bytes): Promise<string> {
-    return this._signDigest(ethers.utils.hashMessage(message));
+  async signMessage(message: string | Bytes): Promise<string> {
+    return this._signDigest(hashMessage(message));
   }
 
-  async signTransaction(transaction: ethers.utils.Deferrable<ethers.providers.TransactionRequest>): Promise<string> {
-    const unsignedTx = await ethers.utils.resolveProperties(transaction);
-    const serializedTx = ethers.utils.serializeTransaction(<UnsignedTransaction>unsignedTx);
-    const transactionSignature = await this._signDigest(ethers.utils.keccak256(serializedTx));
-    return ethers.utils.serializeTransaction(<UnsignedTransaction>unsignedTx, transactionSignature);
+  async signTransaction(transaction: Deferrable<TransactionRequest>): Promise<string> {
+    const unsignedTx = await resolveProperties(transaction);
+    const serializedTx = serializeTransaction(<UnsignedTransaction>unsignedTx);
+    const transactionSignature = await this._signDigest(keccak256(serializedTx));
+    return serializeTransaction(<UnsignedTransaction>unsignedTx, transactionSignature);
   }
 
-  connect(provider: ethers.providers.Provider): AwsKmsSigner {
+  connect(provider: Provider): AwsKmsSigner {
     return new AwsKmsSigner(this.kmsCredentials, provider);
   }
 }

--- a/src/util/aws-kms-utils.ts
+++ b/src/util/aws-kms-utils.ts
@@ -1,7 +1,8 @@
-import { ethers } from "ethers";
 import { KMSClient, SignCommand, GetPublicKeyCommand } from "@aws-sdk/client-kms";
 import * as asn1 from "asn1.js";
 import BN from "bn.js";
+import { keccak256 } from "@ethersproject/keccak256";
+import { recoverAddress } from "@ethersproject/transactions";
 import { AwsKmsSignerCredentials } from "../index";
 
 /* this asn1.js library has some funky things going on */
@@ -54,7 +55,7 @@ export function getEthereumAddress(publicKey: Buffer): string {
   // The public key starts with a 0x04 prefix that needs to be removed
   // more info: https://www.oreilly.com/library/view/mastering-ethereum/9781491971932/ch04.html
   pubKeyBuffer = pubKeyBuffer.slice(1, pubKeyBuffer.length);
-  const address = ethers.utils.keccak256(pubKeyBuffer); // keccak256 hash of publicKey
+  const address = keccak256(pubKeyBuffer); // keccak256 hash of publicKey
   const EthAddr = `0x${address.slice(-40)}`; // take last 20 bytes as ethereum adress
 
   return EthAddr;
@@ -87,7 +88,7 @@ export async function requestKmsSignature(plaintext: Buffer, kmsCredentials: Aws
 }
 
 function recoverPubKeyFromSig(msg: Buffer, r: BN, s: BN, v: number) {
-  return ethers.utils.recoverAddress(`0x${msg.toString("hex")}`, {
+  return recoverAddress(`0x${msg.toString("hex")}`, {
     r: `0x${r.toString("hex")}`,
     s: `0x${s.toString("hex")}`,
     v,


### PR DESCRIPTION
## Summary

What is the background of this pull request?
use ether v5 submodules to resolve https://github.com/advisories/GHSA-3h5v-q93c-6h6q

## Changes

- What are the changes made in this pull request?
- Change this and that, etc...

1. Use only sub modules we need from ethers v5, which does not have the `ws` dependency that is linked to the above mentioned advisory.

## Issues

What are the related issues or stories?
